### PR TITLE
[Feature/api refresh] 리프레쉬 토큰으로 토큰 재발급 후 재요청 기능 추가

### DIFF
--- a/src/apis/utils.ts
+++ b/src/apis/utils.ts
@@ -1,5 +1,9 @@
 import axios from "axios";
 import { secureRoutes } from "./secureRoutes";
+import { ApiEndpotins } from "@/constants/endpoints";
+import type { RefreshTokenResponse } from "@/types/auth";
+import type { ApiResponse } from "./types";
+import type { AxiosResponse } from "axios";
 
 const domain = import.meta.env.VITE_API_DOMAIN;
 
@@ -20,27 +24,6 @@ const axiosInstance = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
-});
-
-axiosInstance.interceptors.request.use((config) => {
-  const url = new URL(config.url as string);
-  const pathname = url.pathname.replace("/api", "");
-
-  // 동적 경로 파라미터를 포함한 URL 패턴 매칭
-  const isProtected = secureRoutes.some((endpoint) => {
-    if (endpoint.method !== config.method) return false;
-
-    // :param 형태의 동적 파라미터를 정규식으로 변환
-    const pattern = endpoint.url.replace(/:[^/]+/g, "[^/]+");
-    const regex = new RegExp(`^${pattern}$`);
-
-    return regex.test(pathname);
-  });
-
-  if (isProtected) {
-    config.headers.Authorization = `Bearer ${localStorage.getItem("accessToken") || ""}`;
-  }
-  return config;
 });
 
 export const api: Api = {
@@ -73,3 +56,61 @@ export const api: Api = {
     return axiosInstance.delete(getDomain(url));
   },
 };
+
+axiosInstance.interceptors.request.use((config) => {
+  const url = new URL(config.url as string);
+  const pathname = url.pathname.replace("/api", "");
+
+  // 동적 경로 파라미터를 포함한 URL 패턴 매칭
+  const isProtected = secureRoutes.some((endpoint) => {
+    if (endpoint.method !== config.method) return false;
+
+    // :param 형태의 동적 파라미터를 정규식으로 변환
+    const pattern = endpoint.url.replace(/:[^/]+/g, "[^/]+");
+    const regex = new RegExp(`^${pattern}$`);
+
+    return regex.test(pathname);
+  });
+
+  if (isProtected) {
+    config.headers.Authorization = `Bearer ${localStorage.getItem("accessToken") || ""}`;
+  }
+  return config;
+});
+
+axiosInstance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+    if (
+      (error.response.status === 403 || error.response.status === 401) &&
+      error.config.url !== ApiEndpotins.REFRESH_TOKEN
+    ) {
+      const refreshToken = localStorage.getItem("refreshToken");
+      if (!refreshToken) return Promise.reject(error);
+
+      try {
+        const response = await api.post<
+          AxiosResponse<ApiResponse<RefreshTokenResponse>>
+        >(ApiEndpotins.REFRESH_TOKEN, {
+          refreshToken,
+        });
+
+        const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
+          response.data.data;
+
+        localStorage.setItem("accessToken", newAccessToken);
+        localStorage.setItem("refreshToken", newRefreshToken);
+        error.config.headers["Authorization"] = `Bearer ${newAccessToken}`;
+
+        return axiosInstance.request(error.config);
+      } catch (err) {
+        console.log("err", err);
+        localStorage.removeItem("accessToken");
+        localStorage.removeItem("refreshToken");
+        return Promise.reject(error);
+      }
+    }
+  }
+);

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -16,6 +16,7 @@ export enum PageEndpoints {
 export enum ApiEndpotins {
   SIGN_IN = "/auth/login",
   SIGN_UP = "/auth/signup",
+  REFRESH_TOKEN = "/auth/refresh",
   ME = "/users/me/info",
   CLUB = "/clubs",
   CLUB_DETAIL = "/clubs/:id",

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -16,3 +16,8 @@ export interface SignUpData {
   position: string;
   university: string;
 }
+
+export interface RefreshTokenResponse {
+  accessToken: string;
+  refreshToken: string;
+}


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- Closes `FRONT_H_087`

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 액세스 토큰이 만료되었거나 존재하지 않을 경우, 리프레시 토큰이 있다면 이를 사용해 토큰을 재발급받고 요청을 다시 보내는 기능을 추가했습니다.

## **✅ 변경 사항**

- axiosInstance에 응답 인터셉터를 추가했습니다.
- 응답이 401또는 403 토큰 관련 에러일 경우, 리프레시 토큰을 통해 액세스 토큰과 리프레시 토큰을 재발급받고 원래 요청을 재전송 하도록 처리했습니다.

## **💬 코멘트**

- 네트워크 요청이 과도하게 발생하거나 예상과 다르게 동작하는 경우 말씀해주세요!
