### PR TITLE
[Feature/api-calendar] 캘린더 일정 추가 및 모달에서 삭제 기능 추가

### DIFF
--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -25,3 +25,5 @@ export const usePostCalendarEvent = (clubId: number) => {
     buildPath(ApiEndpotins.POST_CALENDAR_EVENT, { clubId })
   );
 };
+
+// 동아리 일정 삭제

--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -11,9 +11,12 @@ import type {
 // 캘린더 전체 일정 조회 GET
 export const useGetCalendar = (clubId: number, year: number, month: number) => {
   const path = buildPath(ApiEndpotins.CALENDAR, { clubId });
-  const url = `${path}?year=${year}&month=${month}`;
+  // const url = `${path}?year=${year}&month=${month}`;
 
-  return useFetch<CalendarListType>(url);
+  // return useFetch<CalendarListType>(url);
+  const params = { year, month };
+
+  return useFetch<CalendarListType>(path, params);
 };
 
 // 동아리 일정 추가 POST

--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -11,3 +11,5 @@ export const useGetCalendar = (clubId: number, year: number, month: number) => {
 
   return useFetch<CalendarListType>(url);
 };
+
+// 동아리 일정 추가 POST

--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -1,8 +1,12 @@
 // 동아리 일정 관련 로직들
 import { ApiEndpotins } from "@/constants/endpoints";
 import { buildPath } from "@/utils/buildPath";
-import { useFetch } from "./hooks";
-import type { CalendarListType } from "@/types/calendar";
+import { useFetch, usePost } from "./hooks";
+import type {
+  CalendarListType,
+  ClubEventFormData,
+  ClubEventType,
+} from "@/types/calendar";
 
 // 캘린더 전체 일정 조회 GET
 export const useGetCalendar = (clubId: number, year: number, month: number) => {
@@ -13,3 +17,8 @@ export const useGetCalendar = (clubId: number, year: number, month: number) => {
 };
 
 // 동아리 일정 추가 POST
+export const usePostCalendarEvent = (clubId: number) => {
+  return usePost<ClubEventFormData, ClubEventType>(
+    buildPath(ApiEndpotins.POST_CALENDAR_EVENT, { clubId })
+  );
+};

--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -1,7 +1,7 @@
 // 동아리 일정 관련 로직들
 import { ApiEndpotins } from "@/constants/endpoints";
 import { buildPath } from "@/utils/buildPath";
-import { useFetch, usePost } from "./hooks";
+import { useFetch, usePost, useDelete } from "./hooks";
 import type {
   CalendarListType,
   ClubEventFormData,
@@ -26,4 +26,9 @@ export const usePostCalendarEvent = (clubId: number) => {
   );
 };
 
-// 동아리 일정 삭제
+// 동아리 일정 삭제 DELETE, 경로 파라미터로만 들어감
+export const useDeleteCalendarEvent = (clubId: number, eventId: number) => {
+  return useDelete(
+    buildPath(ApiEndpotins.DELETE_CALENDAR_EVENT, { clubId, eventId })
+  );
+};

--- a/src/apis/secureRoutes.ts
+++ b/src/apis/secureRoutes.ts
@@ -49,4 +49,5 @@ export const secureRoutes = [
 
   { method: Method.GET, url: ApiEndpotins.CALENDAR },
   { method: Method.POST, url: ApiEndpotins.POST_CALENDAR_EVENT },
+  { method: Method.DELETE, url: ApiEndpotins.DELETE_CALENDAR_EVENT },
 ];

--- a/src/apis/secureRoutes.ts
+++ b/src/apis/secureRoutes.ts
@@ -48,4 +48,5 @@ export const secureRoutes = [
   { method: Method.DELETE, url: ApiEndpotins.PROMOTION_DETAIL },
 
   { method: Method.GET, url: ApiEndpotins.CALENDAR },
+  { method: Method.POST, url: ApiEndpotins.POST_CALENDAR_EVENT },
 ];

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -57,4 +57,5 @@ export enum ApiEndpotins {
   // 캘린더용 통합 일정 조회
   CALENDAR = "/clubs/:clubId/calendar",
   POST_CALENDAR_EVENT = "/clubs/:clubId/events", // 동아리 일정 추가
+  DELETE_CALENDAR_EVENT = "/clubs/:clubId/events/:eventId", // 동아리 일정 삭제
 }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -56,4 +56,5 @@ export enum ApiEndpotins {
 
   // 캘린더용 통합 일정 조회
   CALENDAR = "/clubs/:clubId/calendar",
+  POST_CALENDAR_EVENT = "/clubs/:clubId/events", // 동아리 일정 추가
 }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -55,7 +55,7 @@ export enum ApiEndpotins {
   POLL_LIST = "/polls/clubs/:clubId",
 
   // 캘린더용 통합 일정 조회
-  CALENDAR = "/clubs/:clubId/calendar",
+  CALENDAR = "/clubs/:clubId/calendar", // 뒤에 쿼리 파라미터 들어감
   POST_CALENDAR_EVENT = "/clubs/:clubId/events", // 동아리 일정 추가
   DELETE_CALENDAR_EVENT = "/clubs/:clubId/events/:eventId", // 동아리 일정 삭제
 }

--- a/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
@@ -60,7 +60,6 @@ const ScheduleModal = ({ setOpen, currentMonth }: Props) => {
   };
 
   const onSubmit = (data: z.infer<typeof sceduleFormSchema>) => {
-    console.log(data);
     mutate(
       {
         name: data.title,
@@ -91,8 +90,6 @@ const ScheduleModal = ({ setOpen, currentMonth }: Props) => {
   const {
     formState: { errors },
   } = formController;
-
-  console.log("폼 에러", errors);
 
   return (
     <main className={styles.scedule_container}>

--- a/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
@@ -69,9 +69,9 @@ const ScheduleModal = () => {
             {...formController.register("endtime")}
           />
         </Field>
-        <Field label="추가 내용" error={errors.description}>
+        {/* <Field label="추가 내용" error={errors.description}>
           <Input inputSize="sm" {...formController.register("description")} />
-        </Field>
+        </Field> */}
 
         <Button
           type="submit"

--- a/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
@@ -9,6 +9,11 @@ import Button from "@/components/button/Button";
 import { usePostCalendarEvent } from "@/apis/calendar";
 import { useClubStore } from "@/stores/clubStore"; //클럽 id
 
+// invalidateQueries 사용해보기
+import { ApiEndpotins } from "@/constants/endpoints";
+import { useQueryClient } from "@tanstack/react-query";
+import { buildPath } from "@/utils/buildPath";
+
 export const sceduleFormSchema = z
   .object({
     title: z
@@ -35,10 +40,12 @@ export const sceduleFormSchema = z
 
 interface Props {
   setOpen: (open: boolean) => void;
+  currentMonth: Date;
   // refetch: () => void;
 }
 
-const ScheduleModal = ({ setOpen }: Props) => {
+const ScheduleModal = ({ setOpen, currentMonth }: Props) => {
+  const queryClient = useQueryClient();
   // 클럽 아이디
   const clubId = useClubStore((state) => state.clubId);
   const { mutate } = usePostCalendarEvent(clubId!);
@@ -62,7 +69,16 @@ const ScheduleModal = ({ setOpen }: Props) => {
       },
       {
         onSuccess: () => {
-          // refetch();
+          const year = currentMonth.getFullYear();
+          const month = currentMonth.getMonth() + 1;
+
+          queryClient.invalidateQueries({
+            queryKey: [
+              buildPath(ApiEndpotins.CALENDAR, { clubId: clubId! }),
+              { year, month },
+            ] as const,
+          });
+
           setOpen(false);
         },
         onError: (err) => {

--- a/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
@@ -6,6 +6,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import Button from "@/components/button/Button";
 
+import { usePostCalendarEvent } from "@/apis/calendar";
+import { useClubStore } from "@/stores/clubStore"; //클럽 id
+
 export const sceduleFormSchema = z
   .object({
     title: z
@@ -23,24 +26,57 @@ export const sceduleFormSchema = z
       invalid_type_error: "올바른 날짜와 시간을 선택하세요.",
     }),
 
-    description: z.string().max(50, { message: "50자 이내로 입력해주세요." }),
+    // description: z.string().max(50, { message: "50자 이내로 입력해주세요." }),
   })
   .refine((data) => data.endtime > data.starttime, {
     path: ["endtime"],
     message: "마감시간은 시작시간보다 뒤여야 합니다.",
   });
 
-const ScheduleModal = () => {
+interface Props {
+  setOpen: (open: boolean) => void;
+  // refetch: () => void;
+}
+
+const ScheduleModal = ({ setOpen }: Props) => {
+  // 클럽 아이디
+  const clubId = useClubStore((state) => state.clubId);
+  const { mutate } = usePostCalendarEvent(clubId!);
+
   const formController = useForm({
     resolver: zodResolver(sceduleFormSchema),
   });
 
+  const formatKST = (date: Date) => {
+    const tzOffset = date.getTimezoneOffset() * 60000;
+    return new Date(date.getTime() - tzOffset).toISOString().slice(0, -1); // Z 제거
+  };
+
   const onSubmit = (data: z.infer<typeof sceduleFormSchema>) => {
     console.log(data);
+    mutate(
+      {
+        name: data.title,
+        startDatetime: formatKST(data.starttime),
+        endDatetime: formatKST(data.endtime),
+      },
+      {
+        onSuccess: () => {
+          // refetch();
+          setOpen(false);
+        },
+        onError: (err) => {
+          console.error("실패", err);
+        },
+      }
+    );
   };
+
   const {
     formState: { errors },
   } = formController;
+
+  console.log("폼 에러", errors);
 
   return (
     <main className={styles.scedule_container}>

--- a/src/pages/club/detail/clubCalendar/calendar/Calendar.tsx
+++ b/src/pages/club/detail/clubCalendar/calendar/Calendar.tsx
@@ -36,7 +36,7 @@ const Calendar = ({ isMember }: { isMember: boolean }) => {
                 </Button>
               }
             >
-              <ScheduleModal />
+              {(setOpen) => <ScheduleModal setOpen={setOpen} />}
             </Modal>
           )}
         </>

--- a/src/pages/club/detail/clubCalendar/calendar/Calendar.tsx
+++ b/src/pages/club/detail/clubCalendar/calendar/Calendar.tsx
@@ -36,7 +36,9 @@ const Calendar = ({ isMember }: { isMember: boolean }) => {
                 </Button>
               }
             >
-              {(setOpen) => <ScheduleModal setOpen={setOpen} />}
+              {(setOpen) => (
+                <ScheduleModal setOpen={setOpen} currentMonth={currentMonth} />
+              )}
             </Modal>
           )}
         </>

--- a/src/pages/club/detail/clubCalendar/calendar/Calendar.tsx
+++ b/src/pages/club/detail/clubCalendar/calendar/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+// import { useState } from "react";
 import styles from "./Calendar.module.css";
 import Cells from "./Cells";
 import Days from "./Days";
@@ -6,10 +6,13 @@ import Header from "./Header";
 import Modal from "@/components/modal/Modal";
 import Button from "@/components/button/Button";
 import ScheduleModal from "@/pages/club/detail/clubCalendar/ScheduleModal";
+import { useCurrentStore } from "@/stores/currentStore";
 
 const Calendar = ({ isMember }: { isMember: boolean }) => {
-  const [currentMonth, setCurrentMonth] = useState(new Date());
-  const goToday = () => setCurrentMonth(new Date());
+  // const [currentMonth, setCurrentMonth] = useState(new Date());
+  // const goToday = () => setCurrentMonth(new Date());
+
+  const { currentMonth, setCurrentMonth, goToday } = useCurrentStore();
 
   const onChangeDate = (year: number, month: number) => {
     const newDate = new Date(currentMonth);

--- a/src/pages/club/detail/clubCalendar/calendar/Cells.tsx
+++ b/src/pages/club/detail/clubCalendar/calendar/Cells.tsx
@@ -54,9 +54,18 @@ const Cells = ({ currentMonth }: Props) => {
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   let day = new Date(startDate);
 
+  const isSameOrBetween = (date: string, start: string, end: string) => {
+    return date >= start && date <= end;
+  };
+
   const handleDayClick = (date: string) => {
-    const matched = schedules.filter(
-      (s) => format(new Date(s.startDatetime), "yyyy-MM-dd") === date
+    const matched = schedules.filter((s) =>
+      // format(new Date(s.startDatetime), "yyyy-MM-dd") === date
+      {
+        const start = format(new Date(s.startDatetime), "yyyy-MM-dd");
+        const end = format(new Date(s.endDatetime), "yyyy-MM-dd");
+        return isSameOrBetween(date, start, end);
+      }
     );
     setSelectedSchedules(matched);
     setSelectedDate(date);
@@ -75,8 +84,13 @@ const Cells = ({ currentMonth }: Props) => {
       num++; // 셀에 고유한 키
 
       // 일정 라벨
-      const matchedSchedules = schedules.filter(
-        (s) => format(new Date(s.startDatetime), "yyyy-MM-dd") === formattedDate
+      const matchedSchedules = schedules.filter((s) =>
+        // format(new Date(s.startDatetime), "yyyy-MM-dd") === formattedDate
+        {
+          const start = format(new Date(s.startDatetime), "yyyy-MM-dd");
+          const end = format(new Date(s.endDatetime), "yyyy-MM-dd");
+          return isSameOrBetween(formattedDate, start, end);
+        }
       );
 
       // 해당 날짜가 이번 달인가?

--- a/src/pages/club/detail/clubCalendar/calendarLabel/ModalItem.tsx
+++ b/src/pages/club/detail/clubCalendar/calendarLabel/ModalItem.tsx
@@ -1,4 +1,4 @@
-// ScheduleModal에 들어가는
+// ScheduleModal에 들어가는 스케줄 아이템들 (invalidate쿼리를 위해 따로 분리함)
 import { format } from "date-fns";
 import type { CalendarEvent } from "@/types/calendar";
 import { useDeleteCalendarEvent } from "@/apis/calendar";
@@ -13,9 +13,10 @@ import { buildPath } from "@/utils/buildPath";
 
 interface ScheduleItemProps {
   event: CalendarEvent;
+  onDelete: (id: number) => void;
 }
 
-const ModalItem = ({ event }: ScheduleItemProps) => {
+const ModalItem = ({ event, onDelete }: ScheduleItemProps) => {
   const clubId = useClubStore((state) => state.clubId);
   const currentMonth = useCurrentStore((state) => state.currentMonth);
 
@@ -56,21 +57,21 @@ const ModalItem = ({ event }: ScheduleItemProps) => {
       {event.eventType === "CLUB_EVENT" && (
         <button
           onClick={() => {
-            if (confirm("정말 삭제하시겠습니까?")) {
-              deleteEvent(undefined, {
-                onSuccess: () => {
-                  const year = currentMonth.getFullYear();
-                  const month = currentMonth.getMonth() + 1;
+            deleteEvent(undefined, {
+              onSuccess: () => {
+                const year = currentMonth.getFullYear();
+                const month = currentMonth.getMonth() + 1;
 
-                  queryClient.invalidateQueries({
-                    queryKey: [
-                      buildPath(ApiEndpotins.CALENDAR, { clubId: clubId! }),
-                      { year, month },
-                    ] as const,
-                  });
-                },
-              });
-            }
+                onDelete(event.id);
+
+                queryClient.invalidateQueries({
+                  queryKey: [
+                    buildPath(ApiEndpotins.CALENDAR, { clubId: clubId! }),
+                    { year, month },
+                  ] as const,
+                });
+              },
+            });
           }}
         >
           🗑️ 삭제하기

--- a/src/pages/club/detail/clubCalendar/calendarLabel/ModalItem.tsx
+++ b/src/pages/club/detail/clubCalendar/calendarLabel/ModalItem.tsx
@@ -1,0 +1,61 @@
+import { format } from "date-fns";
+import type { CalendarEvent } from "@/types/calendar";
+import { useDeleteCalendarEvent } from "@/apis/calendar";
+import styles from "./ScheduleModal.module.css";
+import { useClubStore } from "@/stores/clubStore";
+
+interface ScheduleItemProps {
+  event: CalendarEvent;
+}
+
+const ModalItem = ({ event }: ScheduleItemProps) => {
+  const clubId = useClubStore((state) => state.clubId);
+  const { mutate: deleteEvent } = useDeleteCalendarEvent(clubId!, event.id);
+
+  const formatTimeRange = (start: string, end: string) => {
+    return `${format(new Date(start), "HH:mm")} ~ ${format(new Date(end), "HH:mm")}`;
+  };
+
+  return (
+    <div
+      className={styles.schedule_label}
+      style={{
+        backgroundColor:
+          event.eventType === "CLUB_EVENT" ? "lightblue" : "pink",
+      }}
+    >
+      <div>{event.name}</div>
+
+      {event.eventType === "TEAM_EVENT" && (
+        <>
+          {event.teamName && (
+            <span className={styles.team_label}>[ 팀 : {event.teamName} ]</span>
+          )}
+          {event.noPosition && (
+            <span className={styles.position_label}>
+              [NO {event.noPosition}]
+            </span>
+          )}
+        </>
+      )}
+
+      <div className={styles.schedule_time}>
+        🕒 [ {formatTimeRange(event.startDatetime, event.endDatetime)} ]
+      </div>
+
+      {event.eventType === "CLUB_EVENT" && (
+        <button
+          onClick={() => {
+            if (confirm("정말 삭제하시겠습니까?")) {
+              deleteEvent();
+            }
+          }}
+        >
+          🗑️ 삭제하기
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ModalItem;

--- a/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
@@ -1,6 +1,6 @@
-import { format } from "date-fns";
 import styles from "./ScheduleModal.module.css";
 import type { CalendarEvent } from "@/types/calendar";
+import ModalItem from "./ModalItem";
 
 interface ScheduleModalProps {
   isOpen: boolean;
@@ -17,11 +17,7 @@ const ScheduleModal = ({
 }: ScheduleModalProps) => {
   if (!isOpen) return null;
 
-  console.log(schedules);
-
-  const formatTimeRange = (start: string, end: string) => {
-    return `${format(new Date(start), "HH:mm")} ~ ${format(new Date(end), "HH:mm")}`;
-  };
+  // console.log(schedules);
 
   return (
     <main className={styles.modal_overlay} onClick={onClose}>
@@ -37,41 +33,7 @@ const ScheduleModal = ({
         {schedules.length === 0 ? (
           <p>등록된 일정이 없습니다.</p>
         ) : (
-          schedules.map((s, i) => (
-            <div
-              key={i}
-              className={styles.schedule_label}
-              style={{
-                backgroundColor:
-                  s.eventType === "CLUB_EVENT" ? "lightblue" : "pink",
-              }}
-            >
-              <div>{s.name}</div>
-              {s.eventType === "TEAM_EVENT" && (
-                <>
-                  {s.teamName && (
-                    <span className={styles.team_label}>
-                      [ 팀 : {s.teamName} ]{" "}
-                    </span>
-                  )}
-                  {s.noPosition && (
-                    <span className={styles.position_label}>
-                      [NO {s.noPosition}]{" "}
-                    </span>
-                  )}
-                </>
-              )}
-              <div className={styles.schedule_time}>
-                🕒 [ {formatTimeRange(s.startDatetime, s.endDatetime)} ]
-              </div>
-
-              {s.eventType === "CLUB_EVENT" && (
-                <>
-                  <button>🗑️ 삭제하기</button>
-                </>
-              )}
-            </div>
-          ))
+          schedules.map((s, i) => <ModalItem key={i} event={s} />)
         )}
       </div>
     </main>

--- a/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
@@ -1,3 +1,5 @@
+// 일정 라벨의 모달
+import { useEffect, useState } from "react";
 import styles from "./ScheduleModal.module.css";
 import type { CalendarEvent } from "@/types/calendar";
 import ModalItem from "./ModalItem";
@@ -15,8 +17,17 @@ const ScheduleModal = ({
   selectedDate,
   onClose,
 }: ScheduleModalProps) => {
+  const [sechedulesState, setScheduleState] = useState<CalendarEvent[]>([]);
+
+  useEffect(() => {
+    setScheduleState(schedules); //props로 받은 스케줄
+  }, [schedules]);
+
   if (!isOpen) return null;
 
+  const handleDeleteState = (id: number) => {
+    setScheduleState((prev) => prev.filter((event) => event.id !== id));
+  };
   return (
     <main className={styles.modal_overlay} onClick={onClose}>
       <div
@@ -31,7 +42,9 @@ const ScheduleModal = ({
         {schedules.length === 0 ? (
           <p>등록된 일정이 없습니다.</p>
         ) : (
-          schedules.map((s, i) => <ModalItem key={i} event={s} />)
+          sechedulesState.map((s, i) => (
+            <ModalItem key={i} event={s} onDelete={handleDeleteState} />
+          ))
         )}
       </div>
     </main>

--- a/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
@@ -17,8 +17,6 @@ const ScheduleModal = ({
 }: ScheduleModalProps) => {
   if (!isOpen) return null;
 
-  // console.log(schedules);
-
   return (
     <main className={styles.modal_overlay} onClick={onClose}>
       <div

--- a/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
@@ -17,6 +17,8 @@ const ScheduleModal = ({
 }: ScheduleModalProps) => {
   if (!isOpen) return null;
 
+  console.log(schedules);
+
   const formatTimeRange = (start: string, end: string) => {
     return `${format(new Date(start), "HH:mm")} ~ ${format(new Date(end), "HH:mm")}`;
   };
@@ -62,6 +64,12 @@ const ScheduleModal = ({
               <div className={styles.schedule_time}>
                 🕒 [ {formatTimeRange(s.startDatetime, s.endDatetime)} ]
               </div>
+
+              {s.eventType === "CLUB_EVENT" && (
+                <>
+                  <button>🗑️ 삭제하기</button>
+                </>
+              )}
             </div>
           ))
         )}

--- a/src/pages/club/detail/clubInfo/ClubInfo.module.css
+++ b/src/pages/club/detail/clubInfo/ClubInfo.module.css
@@ -18,6 +18,14 @@
   top: 9rem;
   right: 0rem;
   z-index: 1;
+  padding: 0.3rem 0.9rem;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.4);
+  border: 0.8px solid rgba(255, 255, 255, 0.6);
+}
+.image_button:hover {
+  background-color: rgba(255, 255, 255, 0.6);
 }
 .title_box {
   display: flex;

--- a/src/stores/currentStore.ts
+++ b/src/stores/currentStore.ts
@@ -1,0 +1,14 @@
+// currentMonth, Year를 저장하기 위한 저장소
+import { create } from "zustand";
+
+interface CurrentStore {
+  currentMonth: Date;
+  setCurrentMonth: (date: Date) => void;
+  goToday: () => void;
+}
+
+export const useCurrentStore = create<CurrentStore>((set) => ({
+  currentMonth: new Date(),
+  setCurrentMonth: (date) => set({ currentMonth: date }),
+  goToday: () => set({ currentMonth: new Date() }),
+}));

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -14,3 +14,15 @@ export interface CalendarEvent {
 
 // 응답 타입
 export type CalendarListType = CalendarEvent[];
+
+// 일정 추가 타입 정의
+export interface ClubEventFormData {
+  name: string;
+  startDatetime: string;
+  endDatetime: string;
+}
+
+// 응답 타입
+export interface ClubEventType extends ClubEventFormData {
+  id: number;
+}


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- Closes #48 
- Closes #46 

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 동아리 일정 추가 및 삭제
- 사진 수정 버튼 design 변경

## **✅ 변경 사항**

- 동아리 일정 추가
  - 추가 설명 부분 주석 처리 (백엔드에도 구현 안되어있음)
  - 일정 추가시 업데이트에 invalidateQueries 적용
  - 일정 날짜가 이틀 이상일 경우 달력에 모두 표시되도록 적용
- 동아리 일정 삭제
  - 일정 클릭 후 모달 들어가면 팀 일정에만 삭제 버튼 구현
  - 삭제 후 달력 invalidateQueries 로 업데이트
  - 모달에서는 데이터를 로컬의 state로 변경하여 일정 삭제 
  설명 : #48
- 사진 수정 버튼 디자인 변경

## **📸 스크린샷 (선택)**

<img width="153" alt="스크린샷 2025-06-06 오후 7 31 25" src="https://github.com/user-attachments/assets/3b860e31-af19-42c4-bee6-b4fabce95545" />

## **💬 코멘트**

- 팀 일정은 팀 페이지에서 삭제 가능하도록 하는게 낫다 해서 캘린더에서는 삭제 버튼 없습니다. 
(백엔드에서도 구현 안한것 확인)
- 팀 일정 추가 및 시간표 페이지 미디어 쿼리 수정 적용 예정
