### PR TITLE
[Feature/api t schedule] 연습 일정 추가 UI 구현 및 개선, API 연결

### DIFF
--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -33,5 +33,19 @@ export const useDeleteCalendarEvent = (clubId: number, eventId: number) => {
   );
 };
 
-// 여기서부터는 팀 일정입니다
 // 팀별 연습 일정 목록 조회
+export const useGetTeamSchedules = (
+  teamId: number,
+  page: number,
+  size: number
+) => {
+  const path = buildPath(ApiEndpotins.TEAM_SCHEDULES, { teamId });
+
+  const params = { page, size };
+  return useFetch(path, params);
+};
+
+// 팀별 연습 일정 생성 POST
+export const usePostTeamSchedules = (teamId: number) => {
+  return usePost(buildPath(ApiEndpotins.TEAM_SCHEDULES, { teamId }));
+};

--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -25,3 +25,5 @@ export const usePostCalendarEvent = (clubId: number) => {
     buildPath(ApiEndpotins.POST_CALENDAR_EVENT, { clubId })
   );
 };
+
+// 동아리 일정 삭제

--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -54,3 +54,10 @@ export const usePostTeamSchedules = (teamId: number) => {
     buildPath(ApiEndpotins.TEAM_SCHEDULES, { teamId })
   );
 };
+
+// 팀 연습 일정 삭제 DELETE
+export const useDeleteTeamSchedule = (teamId: number, scheduleId: number) => {
+  return useDelete(
+    buildPath(ApiEndpotins.DELETE_TEAM_SCHEDULES, { teamId, scheduleId })
+  );
+};

--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -11,9 +11,12 @@ import type {
 // 캘린더 전체 일정 조회 GET
 export const useGetCalendar = (clubId: number, year: number, month: number) => {
   const path = buildPath(ApiEndpotins.CALENDAR, { clubId });
-  const url = `${path}?year=${year}&month=${month}`;
+  // const url = `${path}?year=${year}&month=${month}`;
 
-  return useFetch<CalendarListType>(url);
+  // return useFetch<CalendarListType>(url);
+  const params = { year, month };
+
+  return useFetch<CalendarListType>(path, params);
 };
 
 // 동아리 일정 추가 POST

--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -11,3 +11,5 @@ export const useGetCalendar = (clubId: number, year: number, month: number) => {
 
   return useFetch<CalendarListType>(url);
 };
+
+// 동아리 일정 추가 POST

--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -6,6 +6,9 @@ import type {
   CalendarListType,
   ClubEventFormData,
   ClubEventType,
+  TeamScheduleResponse,
+  PracticeSchedule,
+  TeamScheduleFormData,
 } from "@/types/calendar";
 
 // 캘린더 전체 일정 조회 GET
@@ -42,10 +45,12 @@ export const useGetTeamSchedules = (
   const path = buildPath(ApiEndpotins.TEAM_SCHEDULES, { teamId });
 
   const params = { page, size };
-  return useFetch(path, params);
+  return useFetch<TeamScheduleResponse>(path, params);
 };
 
 // 팀별 연습 일정 생성 POST
 export const usePostTeamSchedules = (teamId: number) => {
-  return usePost(buildPath(ApiEndpotins.TEAM_SCHEDULES, { teamId }));
+  return usePost<TeamScheduleFormData, PracticeSchedule>(
+    buildPath(ApiEndpotins.TEAM_SCHEDULES, { teamId })
+  );
 };

--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -32,3 +32,6 @@ export const useDeleteCalendarEvent = (clubId: number, eventId: number) => {
     buildPath(ApiEndpotins.DELETE_CALENDAR_EVENT, { clubId, eventId })
   );
 };
+
+// 여기서부터는 팀 일정입니다
+// 팀별 연습 일정 목록 조회

--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -1,8 +1,12 @@
 // 동아리 일정 관련 로직들
 import { ApiEndpotins } from "@/constants/endpoints";
 import { buildPath } from "@/utils/buildPath";
-import { useFetch } from "./hooks";
-import type { CalendarListType } from "@/types/calendar";
+import { useFetch, usePost } from "./hooks";
+import type {
+  CalendarListType,
+  ClubEventFormData,
+  ClubEventType,
+} from "@/types/calendar";
 
 // 캘린더 전체 일정 조회 GET
 export const useGetCalendar = (clubId: number, year: number, month: number) => {
@@ -13,3 +17,8 @@ export const useGetCalendar = (clubId: number, year: number, month: number) => {
 };
 
 // 동아리 일정 추가 POST
+export const usePostCalendarEvent = (clubId: number) => {
+  return usePost<ClubEventFormData, ClubEventType>(
+    buildPath(ApiEndpotins.POST_CALENDAR_EVENT, { clubId })
+  );
+};

--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -1,7 +1,7 @@
 // 동아리 일정 관련 로직들
 import { ApiEndpotins } from "@/constants/endpoints";
 import { buildPath } from "@/utils/buildPath";
-import { useFetch, usePost } from "./hooks";
+import { useFetch, usePost, useDelete } from "./hooks";
 import type {
   CalendarListType,
   ClubEventFormData,
@@ -26,4 +26,9 @@ export const usePostCalendarEvent = (clubId: number) => {
   );
 };
 
-// 동아리 일정 삭제
+// 동아리 일정 삭제 DELETE, 경로 파라미터로만 들어감
+export const useDeleteCalendarEvent = (clubId: number, eventId: number) => {
+  return useDelete(
+    buildPath(ApiEndpotins.DELETE_CALENDAR_EVENT, { clubId, eventId })
+  );
+};

--- a/src/apis/secureRoutes.ts
+++ b/src/apis/secureRoutes.ts
@@ -53,4 +53,5 @@ export const secureRoutes = [
 
   { method: Method.GET, url: ApiEndpotins.TEAM_SCHEDULES },
   { method: Method.POST, url: ApiEndpotins.TEAM_SCHEDULES },
+  { method: Method.DELETE, url: ApiEndpotins.DELETE_TEAM_SCHEDULES },
 ];

--- a/src/apis/secureRoutes.ts
+++ b/src/apis/secureRoutes.ts
@@ -49,4 +49,5 @@ export const secureRoutes = [
 
   { method: Method.GET, url: ApiEndpotins.CALENDAR },
   { method: Method.POST, url: ApiEndpotins.POST_CALENDAR_EVENT },
+  { method: Method.DELETE, url: ApiEndpotins.DELETE_CALENDAR_EVENT },
 ];

--- a/src/apis/secureRoutes.ts
+++ b/src/apis/secureRoutes.ts
@@ -48,4 +48,5 @@ export const secureRoutes = [
   { method: Method.DELETE, url: ApiEndpotins.PROMOTION_DETAIL },
 
   { method: Method.GET, url: ApiEndpotins.CALENDAR },
+  { method: Method.POST, url: ApiEndpotins.POST_CALENDAR_EVENT },
 ];

--- a/src/apis/secureRoutes.ts
+++ b/src/apis/secureRoutes.ts
@@ -50,4 +50,7 @@ export const secureRoutes = [
   { method: Method.GET, url: ApiEndpotins.CALENDAR },
   { method: Method.POST, url: ApiEndpotins.POST_CALENDAR_EVENT },
   { method: Method.DELETE, url: ApiEndpotins.DELETE_CALENDAR_EVENT },
+
+  { method: Method.GET, url: ApiEndpotins.TEAM_SCHEDULES },
+  { method: Method.POST, url: ApiEndpotins.TEAM_SCHEDULES },
 ];

--- a/src/components/modal/inviteModal/InviteModal.module.css
+++ b/src/components/modal/inviteModal/InviteModal.module.css
@@ -7,6 +7,11 @@
   gap: 1rem;
 }
 
+.invite_button {
+  padding: 0.5rem 1rem;
+  font-size: var(--text-s);
+}
+
 .container h3 {
   font-size: var(--text-lg);
   color: var(--color-text-sub);

--- a/src/components/modal/inviteModal/InviteModal.module.css
+++ b/src/components/modal/inviteModal/InviteModal.module.css
@@ -10,6 +10,13 @@
 .invite_button {
   padding: 0.5rem 1rem;
   font-size: var(--text-s);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #361f1f;
+}
+.invite_button img {
+  margin-right: 0.3rem;
 }
 
 .container h3 {

--- a/src/components/modal/inviteModal/InviteModal.tsx
+++ b/src/components/modal/inviteModal/InviteModal.tsx
@@ -26,7 +26,11 @@ const InviteModal = ({ data, mutate, type }: InviteModalProps) => {
 
   return (
     <Modal
-      trigger={<Button variant="kakao">팀원 초대</Button>}
+      trigger={
+        <Button variant="kakao" className={styles.invite_button}>
+          팀원 초대
+        </Button>
+      }
       title={`${name} 초대하기`}
     >
       {data ? (

--- a/src/components/modal/inviteModal/InviteModal.tsx
+++ b/src/components/modal/inviteModal/InviteModal.tsx
@@ -7,6 +7,7 @@ import { type AxiosResponse } from "axios";
 import { useEffect, useState } from "react";
 import Modal from "../Modal";
 import styles from "./InviteModal.module.css";
+import kakao from "@/pages/vote/style/kakao.svg";
 
 interface InviteModalProps {
   data: AxiosResponse<ApiResponse<{ link: string }>> | undefined;
@@ -28,6 +29,7 @@ const InviteModal = ({ data, mutate, type }: InviteModalProps) => {
     <Modal
       trigger={
         <Button variant="kakao" className={styles.invite_button}>
+          <img src={kakao} />
           팀원 초대
         </Button>
       }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -57,4 +57,5 @@ export enum ApiEndpotins {
   // 캘린더용 통합 일정 조회
   CALENDAR = "/clubs/:clubId/calendar",
   POST_CALENDAR_EVENT = "/clubs/:clubId/events", // 동아리 일정 추가
+  DELETE_CALENDAR_EVENT = "/clubs/:clubId/events/:eventId", // 동아리 일정 삭제
 }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -56,4 +56,5 @@ export enum ApiEndpotins {
 
   // 캘린더용 통합 일정 조회
   CALENDAR = "/clubs/:clubId/calendar",
+  POST_CALENDAR_EVENT = "/clubs/:clubId/events", // 동아리 일정 추가
 }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -55,7 +55,7 @@ export enum ApiEndpotins {
   POLL_LIST = "/polls/clubs/:clubId",
 
   // 캘린더용 통합 일정 조회
-  CALENDAR = "/clubs/:clubId/calendar",
+  CALENDAR = "/clubs/:clubId/calendar", // 뒤에 쿼리 파라미터 들어감
   POST_CALENDAR_EVENT = "/clubs/:clubId/events", // 동아리 일정 추가
   DELETE_CALENDAR_EVENT = "/clubs/:clubId/events/:eventId", // 동아리 일정 삭제
 }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -59,6 +59,6 @@ export enum ApiEndpotins {
   POST_CALENDAR_EVENT = "/clubs/:clubId/events", // 동아리 일정 추가
   DELETE_CALENDAR_EVENT = "/clubs/:clubId/events/:eventId", // 동아리 일정 삭제
   // 팀 연습 일정 등록 및 조회
-  TEAM_SCHEDULES = "/teams/:teamId/practice-schedules", // 뒤에 쿼리 파라미터 들어감
-  // 연습 일정 생성은 POST로 보내면됨
+  TEAM_SCHEDULES = "/teams/:teamId/practice-schedules",
+  DELETE_TEAM_SCHEDULES = "/teams/:teamId/practice-schedules/:scheduleId", // 팀 연습 일정 삭제
 }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -59,6 +59,6 @@ export enum ApiEndpotins {
   POST_CALENDAR_EVENT = "/clubs/:clubId/events", // 동아리 일정 추가
   DELETE_CALENDAR_EVENT = "/clubs/:clubId/events/:eventId", // 동아리 일정 삭제
   // 팀 연습 일정 등록 및 조회
-  TEAM_SCHEDULES = "/teams/{teamId}/practice-schedules", // 뒤에 쿼리 파라미터 들어감
+  TEAM_SCHEDULES = "/teams/:teamId/practice-schedules", // 뒤에 쿼리 파라미터 들어감
   // 연습 일정 생성은 POST로 보내면됨
 }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -58,4 +58,7 @@ export enum ApiEndpotins {
   CALENDAR = "/clubs/:clubId/calendar", // 뒤에 쿼리 파라미터 들어감
   POST_CALENDAR_EVENT = "/clubs/:clubId/events", // 동아리 일정 추가
   DELETE_CALENDAR_EVENT = "/clubs/:clubId/events/:eventId", // 동아리 일정 삭제
+  // 팀 연습 일정 등록 및 조회
+  TEAM_SCHEDULES = "/teams/{teamId}/practice-schedules", // 뒤에 쿼리 파라미터 들어감
+  // 연습 일정 생성은 POST로 보내면됨
 }

--- a/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
@@ -60,7 +60,6 @@ const ScheduleModal = ({ setOpen, currentMonth }: Props) => {
   };
 
   const onSubmit = (data: z.infer<typeof sceduleFormSchema>) => {
-    console.log(data);
     mutate(
       {
         name: data.title,
@@ -91,8 +90,6 @@ const ScheduleModal = ({ setOpen, currentMonth }: Props) => {
   const {
     formState: { errors },
   } = formController;
-
-  console.log("폼 에러", errors);
 
   return (
     <main className={styles.scedule_container}>

--- a/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
@@ -69,9 +69,9 @@ const ScheduleModal = () => {
             {...formController.register("endtime")}
           />
         </Field>
-        <Field label="추가 내용" error={errors.description}>
+        {/* <Field label="추가 내용" error={errors.description}>
           <Input inputSize="sm" {...formController.register("description")} />
-        </Field>
+        </Field> */}
 
         <Button
           type="submit"

--- a/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
@@ -9,6 +9,11 @@ import Button from "@/components/button/Button";
 import { usePostCalendarEvent } from "@/apis/calendar";
 import { useClubStore } from "@/stores/clubStore"; //클럽 id
 
+// invalidateQueries 사용해보기
+import { ApiEndpotins } from "@/constants/endpoints";
+import { useQueryClient } from "@tanstack/react-query";
+import { buildPath } from "@/utils/buildPath";
+
 export const sceduleFormSchema = z
   .object({
     title: z
@@ -35,10 +40,12 @@ export const sceduleFormSchema = z
 
 interface Props {
   setOpen: (open: boolean) => void;
+  currentMonth: Date;
   // refetch: () => void;
 }
 
-const ScheduleModal = ({ setOpen }: Props) => {
+const ScheduleModal = ({ setOpen, currentMonth }: Props) => {
+  const queryClient = useQueryClient();
   // 클럽 아이디
   const clubId = useClubStore((state) => state.clubId);
   const { mutate } = usePostCalendarEvent(clubId!);
@@ -62,7 +69,16 @@ const ScheduleModal = ({ setOpen }: Props) => {
       },
       {
         onSuccess: () => {
-          // refetch();
+          const year = currentMonth.getFullYear();
+          const month = currentMonth.getMonth() + 1;
+
+          queryClient.invalidateQueries({
+            queryKey: [
+              buildPath(ApiEndpotins.CALENDAR, { clubId: clubId! }),
+              { year, month },
+            ] as const,
+          });
+
           setOpen(false);
         },
         onError: (err) => {

--- a/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/ScheduleModal.tsx
@@ -6,6 +6,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import Button from "@/components/button/Button";
 
+import { usePostCalendarEvent } from "@/apis/calendar";
+import { useClubStore } from "@/stores/clubStore"; //클럽 id
+
 export const sceduleFormSchema = z
   .object({
     title: z
@@ -23,24 +26,57 @@ export const sceduleFormSchema = z
       invalid_type_error: "올바른 날짜와 시간을 선택하세요.",
     }),
 
-    description: z.string().max(50, { message: "50자 이내로 입력해주세요." }),
+    // description: z.string().max(50, { message: "50자 이내로 입력해주세요." }),
   })
   .refine((data) => data.endtime > data.starttime, {
     path: ["endtime"],
     message: "마감시간은 시작시간보다 뒤여야 합니다.",
   });
 
-const ScheduleModal = () => {
+interface Props {
+  setOpen: (open: boolean) => void;
+  // refetch: () => void;
+}
+
+const ScheduleModal = ({ setOpen }: Props) => {
+  // 클럽 아이디
+  const clubId = useClubStore((state) => state.clubId);
+  const { mutate } = usePostCalendarEvent(clubId!);
+
   const formController = useForm({
     resolver: zodResolver(sceduleFormSchema),
   });
 
+  const formatKST = (date: Date) => {
+    const tzOffset = date.getTimezoneOffset() * 60000;
+    return new Date(date.getTime() - tzOffset).toISOString().slice(0, -1); // Z 제거
+  };
+
   const onSubmit = (data: z.infer<typeof sceduleFormSchema>) => {
     console.log(data);
+    mutate(
+      {
+        name: data.title,
+        startDatetime: formatKST(data.starttime),
+        endDatetime: formatKST(data.endtime),
+      },
+      {
+        onSuccess: () => {
+          // refetch();
+          setOpen(false);
+        },
+        onError: (err) => {
+          console.error("실패", err);
+        },
+      }
+    );
   };
+
   const {
     formState: { errors },
   } = formController;
+
+  console.log("폼 에러", errors);
 
   return (
     <main className={styles.scedule_container}>

--- a/src/pages/club/detail/clubCalendar/calendar/Calendar.tsx
+++ b/src/pages/club/detail/clubCalendar/calendar/Calendar.tsx
@@ -36,7 +36,7 @@ const Calendar = ({ isMember }: { isMember: boolean }) => {
                 </Button>
               }
             >
-              <ScheduleModal />
+              {(setOpen) => <ScheduleModal setOpen={setOpen} />}
             </Modal>
           )}
         </>

--- a/src/pages/club/detail/clubCalendar/calendar/Calendar.tsx
+++ b/src/pages/club/detail/clubCalendar/calendar/Calendar.tsx
@@ -36,7 +36,9 @@ const Calendar = ({ isMember }: { isMember: boolean }) => {
                 </Button>
               }
             >
-              {(setOpen) => <ScheduleModal setOpen={setOpen} />}
+              {(setOpen) => (
+                <ScheduleModal setOpen={setOpen} currentMonth={currentMonth} />
+              )}
             </Modal>
           )}
         </>

--- a/src/pages/club/detail/clubCalendar/calendar/Calendar.tsx
+++ b/src/pages/club/detail/clubCalendar/calendar/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+// import { useState } from "react";
 import styles from "./Calendar.module.css";
 import Cells from "./Cells";
 import Days from "./Days";
@@ -6,10 +6,13 @@ import Header from "./Header";
 import Modal from "@/components/modal/Modal";
 import Button from "@/components/button/Button";
 import ScheduleModal from "@/pages/club/detail/clubCalendar/ScheduleModal";
+import { useCurrentStore } from "@/stores/currentStore";
 
 const Calendar = ({ isMember }: { isMember: boolean }) => {
-  const [currentMonth, setCurrentMonth] = useState(new Date());
-  const goToday = () => setCurrentMonth(new Date());
+  // const [currentMonth, setCurrentMonth] = useState(new Date());
+  // const goToday = () => setCurrentMonth(new Date());
+
+  const { currentMonth, setCurrentMonth, goToday } = useCurrentStore();
 
   const onChangeDate = (year: number, month: number) => {
     const newDate = new Date(currentMonth);

--- a/src/pages/club/detail/clubCalendar/calendar/Cells.tsx
+++ b/src/pages/club/detail/clubCalendar/calendar/Cells.tsx
@@ -54,9 +54,18 @@ const Cells = ({ currentMonth }: Props) => {
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   let day = new Date(startDate);
 
+  const isSameOrBetween = (date: string, start: string, end: string) => {
+    return date >= start && date <= end;
+  };
+
   const handleDayClick = (date: string) => {
-    const matched = schedules.filter(
-      (s) => format(new Date(s.startDatetime), "yyyy-MM-dd") === date
+    const matched = schedules.filter((s) =>
+      // format(new Date(s.startDatetime), "yyyy-MM-dd") === date
+      {
+        const start = format(new Date(s.startDatetime), "yyyy-MM-dd");
+        const end = format(new Date(s.endDatetime), "yyyy-MM-dd");
+        return isSameOrBetween(date, start, end);
+      }
     );
     setSelectedSchedules(matched);
     setSelectedDate(date);
@@ -75,8 +84,13 @@ const Cells = ({ currentMonth }: Props) => {
       num++; // 셀에 고유한 키
 
       // 일정 라벨
-      const matchedSchedules = schedules.filter(
-        (s) => format(new Date(s.startDatetime), "yyyy-MM-dd") === formattedDate
+      const matchedSchedules = schedules.filter((s) =>
+        // format(new Date(s.startDatetime), "yyyy-MM-dd") === formattedDate
+        {
+          const start = format(new Date(s.startDatetime), "yyyy-MM-dd");
+          const end = format(new Date(s.endDatetime), "yyyy-MM-dd");
+          return isSameOrBetween(formattedDate, start, end);
+        }
       );
 
       // 해당 날짜가 이번 달인가?

--- a/src/pages/club/detail/clubCalendar/calendarLabel/ModalItem.tsx
+++ b/src/pages/club/detail/clubCalendar/calendarLabel/ModalItem.tsx
@@ -1,4 +1,4 @@
-// ScheduleModal에 들어가는
+// ScheduleModal에 들어가는 스케줄 아이템들 (invalidate쿼리를 위해 따로 분리함)
 import { format } from "date-fns";
 import type { CalendarEvent } from "@/types/calendar";
 import { useDeleteCalendarEvent } from "@/apis/calendar";
@@ -13,9 +13,10 @@ import { buildPath } from "@/utils/buildPath";
 
 interface ScheduleItemProps {
   event: CalendarEvent;
+  onDelete: (id: number) => void;
 }
 
-const ModalItem = ({ event }: ScheduleItemProps) => {
+const ModalItem = ({ event, onDelete }: ScheduleItemProps) => {
   const clubId = useClubStore((state) => state.clubId);
   const currentMonth = useCurrentStore((state) => state.currentMonth);
 
@@ -56,21 +57,21 @@ const ModalItem = ({ event }: ScheduleItemProps) => {
       {event.eventType === "CLUB_EVENT" && (
         <button
           onClick={() => {
-            if (confirm("정말 삭제하시겠습니까?")) {
-              deleteEvent(undefined, {
-                onSuccess: () => {
-                  const year = currentMonth.getFullYear();
-                  const month = currentMonth.getMonth() + 1;
+            deleteEvent(undefined, {
+              onSuccess: () => {
+                const year = currentMonth.getFullYear();
+                const month = currentMonth.getMonth() + 1;
 
-                  queryClient.invalidateQueries({
-                    queryKey: [
-                      buildPath(ApiEndpotins.CALENDAR, { clubId: clubId! }),
-                      { year, month },
-                    ] as const,
-                  });
-                },
-              });
-            }
+                onDelete(event.id);
+
+                queryClient.invalidateQueries({
+                  queryKey: [
+                    buildPath(ApiEndpotins.CALENDAR, { clubId: clubId! }),
+                    { year, month },
+                  ] as const,
+                });
+              },
+            });
           }}
         >
           🗑️ 삭제하기

--- a/src/pages/club/detail/clubCalendar/calendarLabel/ModalItem.tsx
+++ b/src/pages/club/detail/clubCalendar/calendarLabel/ModalItem.tsx
@@ -1,0 +1,61 @@
+import { format } from "date-fns";
+import type { CalendarEvent } from "@/types/calendar";
+import { useDeleteCalendarEvent } from "@/apis/calendar";
+import styles from "./ScheduleModal.module.css";
+import { useClubStore } from "@/stores/clubStore";
+
+interface ScheduleItemProps {
+  event: CalendarEvent;
+}
+
+const ModalItem = ({ event }: ScheduleItemProps) => {
+  const clubId = useClubStore((state) => state.clubId);
+  const { mutate: deleteEvent } = useDeleteCalendarEvent(clubId!, event.id);
+
+  const formatTimeRange = (start: string, end: string) => {
+    return `${format(new Date(start), "HH:mm")} ~ ${format(new Date(end), "HH:mm")}`;
+  };
+
+  return (
+    <div
+      className={styles.schedule_label}
+      style={{
+        backgroundColor:
+          event.eventType === "CLUB_EVENT" ? "lightblue" : "pink",
+      }}
+    >
+      <div>{event.name}</div>
+
+      {event.eventType === "TEAM_EVENT" && (
+        <>
+          {event.teamName && (
+            <span className={styles.team_label}>[ 팀 : {event.teamName} ]</span>
+          )}
+          {event.noPosition && (
+            <span className={styles.position_label}>
+              [NO {event.noPosition}]
+            </span>
+          )}
+        </>
+      )}
+
+      <div className={styles.schedule_time}>
+        🕒 [ {formatTimeRange(event.startDatetime, event.endDatetime)} ]
+      </div>
+
+      {event.eventType === "CLUB_EVENT" && (
+        <button
+          onClick={() => {
+            if (confirm("정말 삭제하시겠습니까?")) {
+              deleteEvent();
+            }
+          }}
+        >
+          🗑️ 삭제하기
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ModalItem;

--- a/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
@@ -1,6 +1,6 @@
-import { format } from "date-fns";
 import styles from "./ScheduleModal.module.css";
 import type { CalendarEvent } from "@/types/calendar";
+import ModalItem from "./ModalItem";
 
 interface ScheduleModalProps {
   isOpen: boolean;
@@ -17,11 +17,7 @@ const ScheduleModal = ({
 }: ScheduleModalProps) => {
   if (!isOpen) return null;
 
-  console.log(schedules);
-
-  const formatTimeRange = (start: string, end: string) => {
-    return `${format(new Date(start), "HH:mm")} ~ ${format(new Date(end), "HH:mm")}`;
-  };
+  // console.log(schedules);
 
   return (
     <main className={styles.modal_overlay} onClick={onClose}>
@@ -37,41 +33,7 @@ const ScheduleModal = ({
         {schedules.length === 0 ? (
           <p>등록된 일정이 없습니다.</p>
         ) : (
-          schedules.map((s, i) => (
-            <div
-              key={i}
-              className={styles.schedule_label}
-              style={{
-                backgroundColor:
-                  s.eventType === "CLUB_EVENT" ? "lightblue" : "pink",
-              }}
-            >
-              <div>{s.name}</div>
-              {s.eventType === "TEAM_EVENT" && (
-                <>
-                  {s.teamName && (
-                    <span className={styles.team_label}>
-                      [ 팀 : {s.teamName} ]{" "}
-                    </span>
-                  )}
-                  {s.noPosition && (
-                    <span className={styles.position_label}>
-                      [NO {s.noPosition}]{" "}
-                    </span>
-                  )}
-                </>
-              )}
-              <div className={styles.schedule_time}>
-                🕒 [ {formatTimeRange(s.startDatetime, s.endDatetime)} ]
-              </div>
-
-              {s.eventType === "CLUB_EVENT" && (
-                <>
-                  <button>🗑️ 삭제하기</button>
-                </>
-              )}
-            </div>
-          ))
+          schedules.map((s, i) => <ModalItem key={i} event={s} />)
         )}
       </div>
     </main>

--- a/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
@@ -1,3 +1,5 @@
+// 일정 라벨의 모달
+import { useEffect, useState } from "react";
 import styles from "./ScheduleModal.module.css";
 import type { CalendarEvent } from "@/types/calendar";
 import ModalItem from "./ModalItem";
@@ -15,8 +17,17 @@ const ScheduleModal = ({
   selectedDate,
   onClose,
 }: ScheduleModalProps) => {
+  const [sechedulesState, setScheduleState] = useState<CalendarEvent[]>([]);
+
+  useEffect(() => {
+    setScheduleState(schedules); //props로 받은 스케줄
+  }, [schedules]);
+
   if (!isOpen) return null;
 
+  const handleDeleteState = (id: number) => {
+    setScheduleState((prev) => prev.filter((event) => event.id !== id));
+  };
   return (
     <main className={styles.modal_overlay} onClick={onClose}>
       <div
@@ -31,7 +42,9 @@ const ScheduleModal = ({
         {schedules.length === 0 ? (
           <p>등록된 일정이 없습니다.</p>
         ) : (
-          schedules.map((s, i) => <ModalItem key={i} event={s} />)
+          sechedulesState.map((s, i) => (
+            <ModalItem key={i} event={s} onDelete={handleDeleteState} />
+          ))
         )}
       </div>
     </main>

--- a/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
@@ -17,8 +17,6 @@ const ScheduleModal = ({
 }: ScheduleModalProps) => {
   if (!isOpen) return null;
 
-  // console.log(schedules);
-
   return (
     <main className={styles.modal_overlay} onClick={onClose}>
       <div

--- a/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
+++ b/src/pages/club/detail/clubCalendar/calendarLabel/ScheduleModal.tsx
@@ -17,6 +17,8 @@ const ScheduleModal = ({
 }: ScheduleModalProps) => {
   if (!isOpen) return null;
 
+  console.log(schedules);
+
   const formatTimeRange = (start: string, end: string) => {
     return `${format(new Date(start), "HH:mm")} ~ ${format(new Date(end), "HH:mm")}`;
   };
@@ -62,6 +64,12 @@ const ScheduleModal = ({
               <div className={styles.schedule_time}>
                 🕒 [ {formatTimeRange(s.startDatetime, s.endDatetime)} ]
               </div>
+
+              {s.eventType === "CLUB_EVENT" && (
+                <>
+                  <button>🗑️ 삭제하기</button>
+                </>
+              )}
             </div>
           ))
         )}

--- a/src/pages/club/detail/clubInfo/ClubInfo.module.css
+++ b/src/pages/club/detail/clubInfo/ClubInfo.module.css
@@ -18,6 +18,14 @@
   top: 9rem;
   right: 0rem;
   z-index: 1;
+  padding: 0.3rem 0.9rem;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.4);
+  border: 0.8px solid rgba(255, 255, 255, 0.6);
+}
+.image_button:hover {
+  background-color: rgba(255, 255, 255, 0.6);
 }
 .title_box {
   display: flex;

--- a/src/pages/team/TeamLayout.tsx
+++ b/src/pages/team/TeamLayout.tsx
@@ -6,9 +6,19 @@ import { TeamDetailProvider } from "./detail/TeamDetailProvider";
 import { Routes } from "react-router-dom";
 import TeamDetail from "./detail/TeamDetail";
 import CreateTimeTable from "./detail/CreateTimeTable";
+import { useTeamStore } from "@/stores/teamStore";
+import { useEffect } from "react";
 
 const TeamLayout = () => {
   const { id } = useParams();
+  const setTeamId = useTeamStore((state) => state.setTeamId);
+
+  useEffect(() => {
+    if (id) {
+      setTeamId(Number(id));
+    }
+  }, [id, setTeamId]);
+
   const location = useLocation();
   const exitTransitionX = location.pathname.includes("/post/timetables")
     ? 70

--- a/src/pages/team/TeamLayout.tsx
+++ b/src/pages/team/TeamLayout.tsx
@@ -1,8 +1,8 @@
 import { Route, useLocation, useParams } from "react-router-dom";
 import { motion } from "framer-motion";
+import { AnimatePresence } from "framer-motion";
 import DefaultLayout from "@/layouts/defaultLayout/DefaultLayout";
 import { TeamDetailProvider } from "./detail/TeamDetailProvider";
-import { AnimatePresence } from "framer-motion";
 import { Routes } from "react-router-dom";
 import TeamDetail from "./detail/TeamDetail";
 import CreateTimeTable from "./detail/CreateTimeTable";

--- a/src/pages/team/detail/CreateTimeTable.tsx
+++ b/src/pages/team/detail/CreateTimeTable.tsx
@@ -1,3 +1,4 @@
+// 내 시간표 입력 페이지
 import { useCallback, useEffect, useState } from "react";
 import styles from "./CreateTimeTable.module.css";
 import TimeScheduler from "@/components/scheduler/TimeScheduler";

--- a/src/pages/team/detail/TeamDetail.module.css
+++ b/src/pages/team/detail/TeamDetail.module.css
@@ -20,12 +20,14 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin-bottom: 1rem;
 }
 
 @media (max-width: 768px) {
   .header {
     text-align: center;
     flex-direction: column;
+    margin-bottom: 0;
   }
   .header h1 {
     padding: 10px;
@@ -60,6 +62,7 @@
   flex: 1;
   display: flex;
   gap: 2rem;
+  margin-top: 1rem;
 }
 
 .content_side_container {

--- a/src/pages/team/detail/TeamDetail.module.css
+++ b/src/pages/team/detail/TeamDetail.module.css
@@ -22,14 +22,39 @@
   align-items: center;
 }
 
+@media (max-width: 768px) {
+  .header {
+    text-align: center;
+    flex-direction: column;
+  }
+  .header h1 {
+    padding: 10px;
+    margin-bottom: 5px;
+    width: 100%;
+  }
+  .header_button_container {
+    margin-bottom: 18px;
+  }
+  .content_container {
+    flex-direction: column;
+    gap: 1rem;
+  }
+}
+
 .header h1 {
-  font-size: var(--text-lg);
+  font-size: var(--text-xl);
   font-weight: var(--font-weight-bold);
+  white-space: nowrap;
 }
 
 .header_button_container {
   display: flex;
   gap: 0.5rem;
+}
+
+.header_button_mytimetable {
+  padding: 0.5rem 1rem;
+  font-size: var(--text-s);
 }
 
 .content_container {
@@ -40,8 +65,7 @@
 
 .content_side_container {
   flex: 1;
-
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1rem;
 }

--- a/src/pages/team/detail/TeamDetail.module.css
+++ b/src/pages/team/detail/TeamDetail.module.css
@@ -37,7 +37,6 @@
   }
   .content_container {
     flex-direction: column;
-    gap: 1rem;
   }
 }
 
@@ -67,5 +66,5 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 3rem;
 }

--- a/src/pages/team/detail/TeamDetail.tsx
+++ b/src/pages/team/detail/TeamDetail.tsx
@@ -1,3 +1,4 @@
+// 팀 페이지
 import TimeScheduler from "@/components/scheduler/TimeScheduler";
 import { useNavigate } from "react-router-dom";
 import styles from "./TeamDetail.module.css";

--- a/src/pages/team/detail/TeamDetail.tsx
+++ b/src/pages/team/detail/TeamDetail.tsx
@@ -37,6 +37,8 @@ const TeamDetail = () => {
                   buildPath(PageEndpoints.POST_TEAM_TIMETABLE, { id: teamId })
                 )
               }
+              size="sm"
+              className={styles.header_button_mytimetable}
             >
               내 시간표 입력
             </Button>

--- a/src/pages/team/detail/quickFilter/QuickFilter.module.css
+++ b/src/pages/team/detail/quickFilter/QuickFilter.module.css
@@ -1,5 +1,5 @@
 .container {
-  min-height: 20rem;
+  /* min-height: 20rem; */
   width: 100%;
 
   display: flex;
@@ -25,6 +25,14 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+@media (max-width: 768px) {
+  .filter_container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
 }
 
 .filter_item {

--- a/src/pages/team/detail/quickFilter/QuickFilter.module.css
+++ b/src/pages/team/detail/quickFilter/QuickFilter.module.css
@@ -35,7 +35,7 @@
   font-weight: var(--font-weight-bold);
   border-radius: var(--radius-3xl);
   box-shadow: var(--shadow-sm);
-  padding: 1rem 1.5rem;
+  padding: 0.6rem 1.2rem;
   text-wrap: nowrap;
   color: var(--color-text-sub);
 }

--- a/src/pages/team/detail/scheduleBoard/AddPractice.module.css
+++ b/src/pages/team/detail/scheduleBoard/AddPractice.module.css
@@ -1,0 +1,32 @@
+.addpractice_container {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.guide {
+  font-size: var(--text-xs);
+  color: #414141;
+}
+
+.addpractice_container span {
+  font-weight: var(--font-weight-bold);
+}
+
+.dot {
+  color: var(--color-primary);
+}
+
+.form_container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.form_container button {
+  font-size: 1rem;
+}

--- a/src/pages/team/detail/scheduleBoard/AddPractice.module.css
+++ b/src/pages/team/detail/scheduleBoard/AddPractice.module.css
@@ -30,3 +30,32 @@
 .form_container button {
   font-size: 1rem;
 }
+
+/* 포지션 선택 */
+.radio_button_group {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.radio_button {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ccc;
+  border-radius: 20px;
+  cursor: pointer;
+  user-select: none;
+  font-size: 14px;
+  background-color: white;
+  transition: all 0.2s;
+}
+
+.radio_input {
+  display: none;
+}
+
+.radio_input:checked + span,
+.radio_button:has(input:checked) {
+  background-color: #7cc5d8;
+  color: white;
+  border-color: #7cc5d8;
+}

--- a/src/pages/team/detail/scheduleBoard/AddPractice.tsx
+++ b/src/pages/team/detail/scheduleBoard/AddPractice.tsx
@@ -10,6 +10,14 @@ import { computeEndDatetime } from "./computeEndTime";
 import { usePostTeamSchedules } from "@/apis/calendar";
 import { useTeamStore } from "@/stores/teamStore";
 
+import { ApiEndpotins } from "@/constants/endpoints";
+import { useQueryClient } from "@tanstack/react-query";
+import { buildPath } from "@/utils/buildPath";
+
+// 일단 고정해놓긴 했는데 변경해야하나?
+const size = 10;
+const page = 0;
+
 interface Props {
   setOpen: (open: boolean) => void;
 }
@@ -47,6 +55,7 @@ const positions = {
 } as const;
 
 export default function AddPractice({ setOpen }: Props) {
+  const queryClient = useQueryClient();
   const teamId = useTeamStore((state) => state.teamId);
   // 스키마랑 연결
   const form = useForm<AddFormData>({
@@ -78,6 +87,13 @@ export default function AddPractice({ setOpen }: Props) {
 
     postSchedules(payload, {
       onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: [
+            buildPath(ApiEndpotins.TEAM_SCHEDULES, { teamId: teamId! }),
+            { page, size },
+          ] as const,
+        });
+
         setOpen(false);
       },
       onError: (err) => {

--- a/src/pages/team/detail/scheduleBoard/AddPractice.tsx
+++ b/src/pages/team/detail/scheduleBoard/AddPractice.tsx
@@ -17,6 +17,9 @@ const addFormSchema = z
     name: z.string().nonempty("캘린더에 표시될 일정 이름을 입력해주세요."),
     startDatetime: z.string().nonempty("시작 시간과 날짜를 선택하세요."),
     endtime: z.string().nonempty("종료 시간을 선택하세요."),
+    noPosition: z
+      .string()
+      .nonempty("불참 포지션을 선택해주세요. 없을 경우 없음을 선택해주세요."),
   })
   .refine(
     (data) => {
@@ -31,6 +34,17 @@ const addFormSchema = z
 
 // 폼 타입 추출
 export type AddFormData = z.infer<typeof addFormSchema>;
+
+// const positions = ["VOCAL", "GUITAR", "KEYBOARD", "BASS", "DRUM", "NULL"];
+
+const positions = {
+  NULL: "없음(전체참여)",
+  VOCAL: "보컬",
+  GUITAR: "기타",
+  KEYBOARD: "키보드",
+  BASS: "베이스",
+  DRUM: "드럼",
+} as const;
 
 export default function AddPractice({ setOpen }: Props) {
   // 스키마랑 연결
@@ -49,12 +63,14 @@ export default function AddPractice({ setOpen }: Props) {
   const onSubmit = (data: AddFormData) => {
     const start = new Date(data.startDatetime);
     const end = computeEndDatetime(data.startDatetime, data.endtime);
+    const finalNoPosition = data.noPosition === "NULL" ? null : data.noPosition;
 
     // 서버와 양식 일치
     const payload = {
       name: data.name,
       startDatetime: formatToServer(start),
       endDatetime: formatToServer(end),
+      noPosition: finalNoPosition,
     };
 
     console.log(payload);
@@ -69,7 +85,11 @@ export default function AddPractice({ setOpen }: Props) {
 
       <form className={styles.form_container} onSubmit={handleSubmit(onSubmit)}>
         <Field label="일정 이름" error={errors.name} isRequired>
-          <Input inputSize="sm" {...form.register("name")} />
+          <Input
+            inputSize="sm"
+            {...form.register("name")}
+            placeholder="예시: 새벽별 합주"
+          />
         </Field>
         <Field label="연습 시간" error={errors.startDatetime} isRequired>
           <Input
@@ -81,6 +101,26 @@ export default function AddPractice({ setOpen }: Props) {
         <Field label="연습 종료 시간" error={errors.endtime} isRequired>
           <Input inputSize="sm" type="time" {...form.register("endtime")} />
         </Field>
+
+        <Field label="불참 포지션" error={errors.noPosition} isRequired>
+          <div className={styles.radio_button_group}>
+            {Object.entries(positions).map(([key, label]) => (
+              <label key={key} className={styles.radio_button}>
+                <input
+                  type="radio"
+                  value={key}
+                  {...form.register("noPosition")}
+                  className={styles.radio_input}
+                />
+                <span>{label}</span>
+              </label>
+            ))}
+          </div>
+        </Field>
+        <p className={styles.guide}>
+          등록한 일정은 동아리 메인 캘린더에서도 확인이 가능합니다.
+        </p>
+
         <Button type="submit" size="md" variant="secondary">
           일정 등록하기
         </Button>

--- a/src/pages/team/detail/scheduleBoard/AddPractice.tsx
+++ b/src/pages/team/detail/scheduleBoard/AddPractice.tsx
@@ -11,9 +11,27 @@ interface Props {
   setOpen: (open: boolean) => void;
 }
 
-const addFormSchema = z.object({
-  name: z.string().nonempty("캘린더에 표시될 일정 이름을 입력해주세요."),
-});
+const addFormSchema = z
+  .object({
+    name: z.string().nonempty("캘린더에 표시될 일정 이름을 입력해주세요."),
+    startDatetime: z.string().nonempty("시작 시간과 날짜를 선택하세요."),
+    endtime: z.string().nonempty("종료 시간을 선택하세요."),
+  })
+  .refine(
+    (data) => {
+      // 스타트 시간
+      const start = new Date(data.startDatetime);
+      // [시간,분] 으로 각각의 숫자를 분리해서 넣어놓음
+      const [endHour, endMinute] = data.endtime.split(":").map(Number);
+      const end = new Date(start); // ex) new Date("2024-06-06T16:00") 가 됨
+      end.setHours(endHour, endMinute); // Date에서 기본으로 제공되는 메서드임.
+      return end > start;
+    },
+    {
+      path: ["endtime"], // 에러 표시할 필드 설정
+      message: "종료 시간은 시작 시간보다 늦어야 합니다.",
+    }
+  );
 
 // 폼 타입 추출
 export type AddFormData = z.infer<typeof addFormSchema>;
@@ -43,6 +61,16 @@ export default function AddPractice({ setOpen }: Props) {
       <form className={styles.form_container} onSubmit={handleSubmit(onSubmit)}>
         <Field label="일정 이름" error={errors.name} isRequired>
           <Input inputSize="sm" {...form.register("name")} />
+        </Field>
+        <Field label="연습 시간" error={errors.startDatetime} isRequired>
+          <Input
+            inputSize="sm"
+            type="datetime-local"
+            {...form.register("startDatetime")}
+          />
+        </Field>
+        <Field label="연습 종료 시간" error={errors.endtime} isRequired>
+          <Input inputSize="sm" type="time" {...form.register("endtime")} />
         </Field>
         <Button type="submit" size="md" variant="secondary">
           일정 등록하기

--- a/src/pages/team/detail/scheduleBoard/AddPractice.tsx
+++ b/src/pages/team/detail/scheduleBoard/AddPractice.tsx
@@ -1,0 +1,53 @@
+// 스케줄 등록 모달에 들어갈 내용
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import styles from "@/pages/team/detail/scheduleBoard/AddPractice.module.css";
+import Field from "@/components/field/Field";
+import Input from "@/components/input/Input";
+import Button from "@/components/button/Button";
+
+interface Props {
+  setOpen: (open: boolean) => void;
+}
+
+const addFormSchema = z.object({
+  name: z.string().nonempty("캘린더에 표시될 일정 이름을 입력해주세요."),
+});
+
+// 폼 타입 추출
+export type AddFormData = z.infer<typeof addFormSchema>;
+
+export default function AddPractice({ setOpen }: Props) {
+  // 스키마랑 연결
+  const form = useForm<AddFormData>({
+    resolver: zodResolver(addFormSchema),
+  });
+
+  const {
+    formState: { errors },
+    handleSubmit,
+  } = form;
+
+  const onSubmit = (data: AddFormData) => {
+    console.log(data);
+    setOpen(false);
+  };
+
+  return (
+    <main className={styles.addpractice_container}>
+      <p className={styles.guide}>
+        <span className={styles.dot}>*</span> 는 필수 입력 항목입니다.
+      </p>
+
+      <form className={styles.form_container} onSubmit={handleSubmit(onSubmit)}>
+        <Field label="일정 이름" error={errors.name} isRequired>
+          <Input inputSize="sm" {...form.register("name")} />
+        </Field>
+        <Button type="submit" size="md" variant="secondary">
+          일정 등록하기
+        </Button>
+      </form>
+    </main>
+  );
+}

--- a/src/pages/team/detail/scheduleBoard/AddPractice.tsx
+++ b/src/pages/team/detail/scheduleBoard/AddPractice.tsx
@@ -6,6 +6,7 @@ import styles from "@/pages/team/detail/scheduleBoard/AddPractice.module.css";
 import Field from "@/components/field/Field";
 import Input from "@/components/input/Input";
 import Button from "@/components/button/Button";
+import { computeEndDatetime } from "./computeEndTime";
 
 interface Props {
   setOpen: (open: boolean) => void;
@@ -19,13 +20,8 @@ const addFormSchema = z
   })
   .refine(
     (data) => {
-      // 스타트 시간
-      const start = new Date(data.startDatetime);
-      // [시간,분] 으로 각각의 숫자를 분리해서 넣어놓음
-      const [endHour, endMinute] = data.endtime.split(":").map(Number);
-      const end = new Date(start); // ex) new Date("2024-06-06T16:00") 가 됨
-      end.setHours(endHour, endMinute); // Date에서 기본으로 제공되는 메서드임.
-      return end > start;
+      const end = computeEndDatetime(data.startDatetime, data.endtime);
+      return end > new Date(data.startDatetime);
     },
     {
       path: ["endtime"], // 에러 표시할 필드 설정
@@ -47,8 +43,21 @@ export default function AddPractice({ setOpen }: Props) {
     handleSubmit,
   } = form;
 
+  // 서버로 전송하기 위해 형식 변경 (서버와 일치)
+  const formatToServer = (date: Date) => date.toISOString().slice(0, 19);
+
   const onSubmit = (data: AddFormData) => {
-    console.log(data);
+    const start = new Date(data.startDatetime);
+    const end = computeEndDatetime(data.startDatetime, data.endtime);
+
+    // 서버와 양식 일치
+    const payload = {
+      name: data.name,
+      startDatetime: formatToServer(start),
+      endDatetime: formatToServer(end),
+    };
+
+    console.log(payload);
     setOpen(false);
   };
 

--- a/src/pages/team/detail/scheduleBoard/DeleteButton.tsx
+++ b/src/pages/team/detail/scheduleBoard/DeleteButton.tsx
@@ -1,0 +1,26 @@
+import { useDeleteTeamSchedule } from "@/apis/calendar";
+import { useTeamStore } from "@/stores/teamStore";
+import styles from "./ScheduleBoard.module.css";
+
+export const DeleteButton = ({ scheduleId }: { scheduleId: number }) => {
+  const teamId = useTeamStore((state) => state.teamId);
+  const { mutate: deleteEvent } = useDeleteTeamSchedule(teamId!, scheduleId);
+
+  const handleDelete = () => {
+    deleteEvent(undefined, {
+      onSuccess: () => {
+        console.log("삭제 완료");
+      },
+    });
+  };
+
+  return (
+    <button
+      className={styles.delete_btn}
+      onClick={handleDelete}
+      aria-label="삭제"
+    >
+      ✕
+    </button>
+  );
+};

--- a/src/pages/team/detail/scheduleBoard/DeleteButton.tsx
+++ b/src/pages/team/detail/scheduleBoard/DeleteButton.tsx
@@ -2,14 +2,27 @@ import { useDeleteTeamSchedule } from "@/apis/calendar";
 import { useTeamStore } from "@/stores/teamStore";
 import styles from "./ScheduleBoard.module.css";
 
+import { ApiEndpotins } from "@/constants/endpoints";
+import { useQueryClient } from "@tanstack/react-query";
+import { buildPath } from "@/utils/buildPath";
+
+const size = 10;
+const page = 0;
+
 export const DeleteButton = ({ scheduleId }: { scheduleId: number }) => {
   const teamId = useTeamStore((state) => state.teamId);
   const { mutate: deleteEvent } = useDeleteTeamSchedule(teamId!, scheduleId);
+  const queryClient = useQueryClient();
 
   const handleDelete = () => {
     deleteEvent(undefined, {
       onSuccess: () => {
-        console.log("삭제 완료");
+        queryClient.invalidateQueries({
+          queryKey: [
+            buildPath(ApiEndpotins.TEAM_SCHEDULES, { teamId: teamId! }),
+            { page, size },
+          ] as const,
+        });
       },
     });
   };

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.module.css
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.module.css
@@ -33,23 +33,35 @@
   gap: 1.5rem;
 }
 
+.content_item_info {
+  margin-top: 0.5rem;
+}
+
+.content_item_info span {
+  font-weight: var(--font-weight-bold);
+}
+.content_item_info p {
+  font-size: var(--text-sm);
+}
+
 .content_item {
   position: relative;
-  background: var(--bg-color);
   border-radius: var(--radius-3xl);
   box-shadow: var(--shadow-sm);
   padding: 1rem 1.5rem;
   text-wrap: nowrap;
+  color: #343434;
 }
 
 .content_type {
   position: absolute;
   top: -12px;
   left: 4px;
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-bold);
   font-size: var(--text-sm);
-  padding: 0.25rem 0.5rem;
+  padding: 0.4rem 0.8rem;
   border-radius: var(--radius-3xl);
-  background: oklch(82.82% 0.0843 199.13);
+  background: var(--bg-color);
   box-shadow: var(--shadow-md);
+  color: var(--color-white);
 }

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.module.css
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.module.css
@@ -66,3 +66,21 @@
   box-shadow: var(--shadow-md);
   color: var(--color-white);
 }
+
+/* 페이지네이션 */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.pagination button {
+  cursor: pointer;
+}
+
+.pagination button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.module.css
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.module.css
@@ -84,3 +84,10 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+.empty_message {
+  margin-top: 1rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-sub);
+}

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.module.css
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.module.css
@@ -92,3 +92,21 @@
   font-weight: var(--font-weight-bold);
   color: var(--color-text-sub);
 }
+
+/* 삭제 추가 */
+.delete_btn {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 18px;
+  color: #ccc;
+  cursor: pointer;
+  padding: 4px;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: rgb(255, 90, 90);
+  }
+}

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.module.css
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.module.css
@@ -43,6 +43,7 @@
 }
 .content_item_info p {
   font-size: var(--text-sm);
+  margin-top: 0.5rem;
 }
 
 .content_item {

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.module.css
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.module.css
@@ -39,6 +39,7 @@
 
 .content_item_info span {
   font-weight: var(--font-weight-bold);
+  white-space: wrap;
 }
 .content_item_info p {
   font-size: var(--text-sm);

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
@@ -20,8 +20,10 @@ const ScheduleBoard = () => {
             <span className={styles.content_type}>
               {item.noPosition !== null ? `NO ${item.noPosition}` : "전체"}
             </span>
-            <span>{item.name}</span>
-            <p>{`${format(new Date(item.startDatetime), "MM월 dd일 HH:mm")}~${format(new Date(item.endDatetime), "HH:mm")}`}</p>
+            <div className={styles.content_item_info}>
+              <span>{item.name}</span>
+              <p>{`${format(new Date(item.startDatetime), "MM월 dd일 HH:mm")} ~ ${format(new Date(item.endDatetime), "HH:mm")}`}</p>
+            </div>
           </div>
         ))}
       </div>

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
@@ -1,16 +1,25 @@
 import styles from "./ScheduleBoard.module.css";
 import { format } from "date-fns";
 import { FiPlus } from "react-icons/fi";
+import Modal from "@/components/modal/Modal";
 import { dummyTeamSchedule } from "./dummyTeamSchedule";
+import AddPractice from "./AddPractice";
 
 const ScheduleBoard = () => {
   return (
     <section className={styles.container}>
       <header className={styles.header}>
         <h2>팀 연습 일정</h2>
-        <button className={styles.header_button}>
-          <FiPlus size={20} />
-        </button>
+        <Modal
+          title="팀 연습 일정 등록하기"
+          trigger={
+            <button className={styles.header_button}>
+              <FiPlus size={20} />
+            </button>
+          }
+        >
+          {(setOpen) => <AddPractice setOpen={setOpen} />}
+        </Modal>
       </header>
 
       {/* 연습일정 */}

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
@@ -1,5 +1,7 @@
 import styles from "./ScheduleBoard.module.css";
+import { format } from "date-fns";
 import { FiPlus } from "react-icons/fi";
+import { dummyTeamSchedule } from "./dummyTeamSchedule";
 
 const ScheduleBoard = () => {
   return (
@@ -11,14 +13,18 @@ const ScheduleBoard = () => {
         </button>
       </header>
 
-      {/* <div className={styles.content_container}>
-        {dummyTeam.practiceTime.map((time) => (
-          <div className={styles.content_item} key={time.id}>
-            <span className={styles.content_type}>{time.type}</span>
-            <span>{time.time}</span>
+      {/* 연습일정 */}
+      <div className={styles.content_container}>
+        {dummyTeamSchedule.map((item) => (
+          <div className={styles.content_item} key={item.id}>
+            <span className={styles.content_type}>
+              {item.noPosition !== null ? `NO ${item.noPosition}` : "전체"}
+            </span>
+            <span>{item.name}</span>
+            <p>{`${format(new Date(item.startDatetime), "MM월 dd일 HH:mm")}~${format(new Date(item.endDatetime), "HH:mm")}`}</p>
           </div>
         ))}
-      </div> */}
+      </div>
     </section>
   );
 };

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
@@ -6,6 +6,7 @@ import Modal from "@/components/modal/Modal";
 import AddPractice from "./AddPractice";
 import { useGetTeamSchedules } from "@/apis/calendar";
 import { useTeamStore } from "@/stores/teamStore";
+import { DeleteButton } from "./DeleteButton";
 
 const size = 10;
 
@@ -55,6 +56,8 @@ const ScheduleBoard = () => {
                 <span className={styles.content_type}>
                   {item.noPosition ? positionLabelMap[item.noPosition] : "전체"}
                 </span>
+                <DeleteButton scheduleId={item.id} />
+
                 <div className={styles.content_item_info}>
                   <span>{item.name}</span>
                   <p>{`${format(new Date(item.startDatetime), "MM월 dd일 HH:mm")} ~ ${format(new Date(item.endDatetime), "HH:mm")}`}</p>

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
@@ -1,11 +1,23 @@
+// import { useState } from "react";
 import styles from "./ScheduleBoard.module.css";
 import { format } from "date-fns";
 import { FiPlus } from "react-icons/fi";
 import Modal from "@/components/modal/Modal";
 import { dummyTeamSchedule } from "./dummyTeamSchedule";
 import AddPractice from "./AddPractice";
+// import { useGetTeamSchedules } from "@/apis/calendar"
+// import { useTeamStore } from "@/stores/teamStore";
+
+// const size = 10;
 
 const ScheduleBoard = () => {
+  // const teamId = useTeamStore((state) => state.teamId);
+  // const [page, setPage] = useState(0);
+  // const { data } = useGetTeamSchedules(teamId!, page, size);
+
+  // const schedules = data?.data.content ?? [];
+  // const pageInfo = data?.data.pageInfo;
+
   return (
     <section className={styles.container}>
       <header className={styles.header}>

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
@@ -1,22 +1,21 @@
-// import { useState } from "react";
+import { useState } from "react";
 import styles from "./ScheduleBoard.module.css";
 import { format } from "date-fns";
 import { FiPlus } from "react-icons/fi";
 import Modal from "@/components/modal/Modal";
-import { dummyTeamSchedule } from "./dummyTeamSchedule";
 import AddPractice from "./AddPractice";
-// import { useGetTeamSchedules } from "@/apis/calendar"
-// import { useTeamStore } from "@/stores/teamStore";
+import { useGetTeamSchedules } from "@/apis/calendar";
+import { useTeamStore } from "@/stores/teamStore";
 
-// const size = 10;
+const size = 10;
 
 const ScheduleBoard = () => {
-  // const teamId = useTeamStore((state) => state.teamId);
-  // const [page, setPage] = useState(0);
-  // const { data } = useGetTeamSchedules(teamId!, page, size);
+  const teamId = useTeamStore((state) => state.teamId);
+  const [page, setPage] = useState(0);
+  const { data } = useGetTeamSchedules(teamId!, page, size);
 
-  // const schedules = data?.data.content ?? [];
-  // const pageInfo = data?.data.pageInfo;
+  const schedules = data?.data.content ?? [];
+  const pageInfo = data?.data.pageInfo;
 
   return (
     <section className={styles.container}>
@@ -35,19 +34,44 @@ const ScheduleBoard = () => {
       </header>
 
       {/* 연습일정 */}
-      <div className={styles.content_container}>
-        {dummyTeamSchedule.map((item) => (
-          <div className={styles.content_item} key={item.id}>
-            <span className={styles.content_type}>
-              {item.noPosition !== null ? `NO ${item.noPosition}` : "전체"}
-            </span>
-            <div className={styles.content_item_info}>
-              <span>{item.name}</span>
-              <p>{`${format(new Date(item.startDatetime), "MM월 dd일 HH:mm")} ~ ${format(new Date(item.endDatetime), "HH:mm")}`}</p>
-            </div>
+      {pageInfo?.totalElements === 0 ? (
+        <p className={styles.empty_message}>
+          연습 일정이 없습니다. <br />
+        </p>
+      ) : (
+        <>
+          <div className={styles.content_container}>
+            {schedules.map((item) => (
+              <div className={styles.content_item} key={item.id}>
+                <span className={styles.content_type}>
+                  {item.noPosition !== null ? `NO ${item.noPosition}` : "전체"}
+                </span>
+                <div className={styles.content_item_info}>
+                  <span>{item.name}</span>
+                  <p>{`${format(new Date(item.startDatetime), "MM월 dd일 HH:mm")} ~ ${format(new Date(item.endDatetime), "HH:mm")}`}</p>
+                </div>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
+          <div className={styles.pagination}>
+            <button
+              onClick={() => setPage((prev) => prev - 1)}
+              disabled={pageInfo?.first}
+            >
+              이전
+            </button>
+            <span>
+              {page + 1} / {pageInfo?.totalPages}
+            </span>
+            <button
+              onClick={() => setPage((prev) => prev + 1)}
+              disabled={pageInfo?.last}
+            >
+              다음
+            </button>
+          </div>
+        </>
+      )}
     </section>
   );
 };

--- a/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
+++ b/src/pages/team/detail/scheduleBoard/ScheduleBoard.tsx
@@ -9,6 +9,15 @@ import { useTeamStore } from "@/stores/teamStore";
 
 const size = 10;
 
+const positionLabelMap: Record<string, string> = {
+  NONE: "전체",
+  VOCAL: "보컬제외",
+  GUITAR: "기타제외",
+  KEYBOARD: "키보드제외",
+  BASS: "베이스제외",
+  DRUM: "드럼제외",
+};
+
 const ScheduleBoard = () => {
   const teamId = useTeamStore((state) => state.teamId);
   const [page, setPage] = useState(0);
@@ -44,7 +53,7 @@ const ScheduleBoard = () => {
             {schedules.map((item) => (
               <div className={styles.content_item} key={item.id}>
                 <span className={styles.content_type}>
-                  {item.noPosition !== null ? `NO ${item.noPosition}` : "전체"}
+                  {item.noPosition ? positionLabelMap[item.noPosition] : "전체"}
                 </span>
                 <div className={styles.content_item_info}>
                   <span>{item.name}</span>

--- a/src/pages/team/detail/scheduleBoard/computeEndTime.ts
+++ b/src/pages/team/detail/scheduleBoard/computeEndTime.ts
@@ -1,0 +1,13 @@
+// 시간만 받는 end time을 비교하고, 서버 전송 양식을 맞추기 위한 함수
+export const computeEndDatetime = (
+  startDatetime: string,
+  endTime: string
+): Date => {
+  // 스타트 시간
+  const start = new Date(startDatetime);
+  // [시간,분] 으로 각각의 숫자를 분리해서 넣어놓음
+  const [endHour, endMinute] = endTime.split(":").map(Number);
+  const end = new Date(start); // ex) new Date("2024-06-06T16:00") 가 됨
+  end.setHours(endHour, endMinute); // Date에서 기본으로 제공되는 메서드임.
+  return end;
+};

--- a/src/pages/team/detail/scheduleBoard/dummyTeamSchedule.ts
+++ b/src/pages/team/detail/scheduleBoard/dummyTeamSchedule.ts
@@ -30,7 +30,7 @@ export const dummyTeamSchedule: PracticeSchedule[] = [
     id: 2,
     teamId: 1,
     teamName: "락밴드 A팀",
-    name: "니르바나 합주",
+    name: "헤브유씬더레인ㅋ",
     startDatetime: "2024-03-17T18:00:00",
     endDatetime: "2024-03-17T20:00:00",
     noPosition: "GUITAR",

--- a/src/pages/team/detail/scheduleBoard/dummyTeamSchedule.ts
+++ b/src/pages/team/detail/scheduleBoard/dummyTeamSchedule.ts
@@ -1,16 +1,4 @@
-export interface PracticeSchedule {
-  id: number;
-  teamId: number;
-  teamName: string;
-  name: string;
-  startDatetime: string;
-  endDatetime: string;
-  noPosition: string | null;
-  creatorId: number;
-  creatorName: string;
-  createdAt: string;
-  updatedAt: string;
-}
+import type { PracticeSchedule } from "@/types/calendar";
 
 export const dummyTeamSchedule: PracticeSchedule[] = [
   {

--- a/src/pages/team/detail/scheduleBoard/dummyTeamSchedule.ts
+++ b/src/pages/team/detail/scheduleBoard/dummyTeamSchedule.ts
@@ -1,0 +1,81 @@
+export interface PracticeSchedule {
+  id: number;
+  teamId: number;
+  teamName: string;
+  name: string;
+  startDatetime: string;
+  endDatetime: string;
+  noPosition: string | null;
+  creatorId: number;
+  creatorName: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const dummyTeamSchedule: PracticeSchedule[] = [
+  {
+    id: 1,
+    teamId: 1,
+    teamName: "락밴드 A팀",
+    name: "보헤미안랩소디 합주",
+    startDatetime: "2024-03-15T19:00:00",
+    endDatetime: "2024-03-15T21:00:00",
+    noPosition: "VOCAL",
+    creatorId: 1,
+    creatorName: "홍길동",
+    createdAt: "2024-03-15T10:30:00",
+    updatedAt: "2024-03-15T10:30:00",
+  },
+  {
+    id: 2,
+    teamId: 1,
+    teamName: "락밴드 A팀",
+    name: "니르바나 합주",
+    startDatetime: "2024-03-17T18:00:00",
+    endDatetime: "2024-03-17T20:00:00",
+    noPosition: "GUITAR",
+    creatorId: 2,
+    creatorName: "강멧돌",
+    createdAt: "2024-03-16T14:15:00",
+    updatedAt: "2024-03-16T14:15:00",
+  },
+  {
+    id: 3,
+    teamId: 1,
+    teamName: "락밴드 A팀",
+    name: "Hotel California",
+    startDatetime: "2024-03-20T20:00:00",
+    endDatetime: "2024-03-20T22:00:00",
+    noPosition: null,
+    creatorId: 2,
+    creatorName: "강멧돌",
+    createdAt: "2024-03-18T11:00:00",
+    updatedAt: "2024-03-18T11:00:00",
+  },
+  {
+    id: 4,
+    teamId: 1,
+    teamName: "락밴드 A팀",
+    name: "Sweet Child O' Mine",
+    startDatetime: "2024-03-22T17:30:00",
+    endDatetime: "2024-03-22T19:30:00",
+    noPosition: "BASS",
+    creatorId: 4,
+    creatorName: "김응가",
+    createdAt: "2024-03-21T09:00:00",
+    updatedAt: "2024-03-21T09:00:00",
+  },
+  {
+    id: 5,
+    teamId: 1,
+    teamName: "락밴드 A팀",
+    name: "Don't Stop Believin' - Journey",
+    startDatetime: "2024-03-25T18:00:00",
+    endDatetime: "2024-03-25T20:00:00",
+    noPosition: "KEYBOARD",
+    creatorId: 5,
+    creatorName: "본조비",
+    createdAt: "2024-03-24T13:45:00",
+    updatedAt: "2024-03-24T13:45:00",
+  },
+];

--- a/src/pages/team/detail/scheduleBoard/dummyTeamSchedule.ts
+++ b/src/pages/team/detail/scheduleBoard/dummyTeamSchedule.ts
@@ -69,7 +69,7 @@ export const dummyTeamSchedule: PracticeSchedule[] = [
     id: 5,
     teamId: 1,
     teamName: "락밴드 A팀",
-    name: "Don't Stop Believin' - Journey",
+    name: "Don't Stop Believin' - Journefdfddfdfay",
     startDatetime: "2024-03-25T18:00:00",
     endDatetime: "2024-03-25T20:00:00",
     noPosition: "KEYBOARD",

--- a/src/pages/vote/select/Vote.module.css
+++ b/src/pages/vote/select/Vote.module.css
@@ -24,6 +24,9 @@
 .share {
   display: flex;
   background-color: #f6df00;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   color: #361f1f;
 }
 .share img {

--- a/src/stores/currentStore.ts
+++ b/src/stores/currentStore.ts
@@ -1,0 +1,14 @@
+// currentMonth, Year를 저장하기 위한 저장소
+import { create } from "zustand";
+
+interface CurrentStore {
+  currentMonth: Date;
+  setCurrentMonth: (date: Date) => void;
+  goToday: () => void;
+}
+
+export const useCurrentStore = create<CurrentStore>((set) => ({
+  currentMonth: new Date(),
+  setCurrentMonth: (date) => set({ currentMonth: date }),
+  goToday: () => set({ currentMonth: new Date() }),
+}));

--- a/src/stores/teamStore.ts
+++ b/src/stores/teamStore.ts
@@ -1,0 +1,12 @@
+// 팀 아이디 저장을 위한 store
+import { create } from "zustand";
+
+interface TeamStore {
+  teamId: number | null;
+  setTeamId: (id: number) => void;
+}
+
+export const useTeamStore = create<TeamStore>((set) => ({
+  teamId: null,
+  setTeamId: (id) => set({ teamId: id }),
+}));

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -14,3 +14,15 @@ export interface CalendarEvent {
 
 // 응답 타입
 export type CalendarListType = CalendarEvent[];
+
+// 일정 추가 타입 정의
+export interface ClubEventFormData {
+  name: string;
+  startDatetime: string;
+  endDatetime: string;
+}
+
+// 응답 타입
+export interface ClubEventType extends ClubEventFormData {
+  id: number;
+}

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -26,3 +26,33 @@ export interface ClubEventFormData {
 export interface ClubEventType extends ClubEventFormData {
   id: number;
 }
+
+// 동아리 응답 타입
+export interface PracticeSchedule {
+  id: number;
+  teamId: number;
+  teamName: string;
+  name: string;
+  startDatetime: string;
+  endDatetime: string;
+  noPosition: string | null;
+  creatorId: number;
+  creatorName: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PageInfo {
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  first: boolean;
+  last: boolean;
+  empty: boolean;
+}
+
+export interface TeamScheduleResponse {
+  content: PracticeSchedule[];
+  pageInfo: PageInfo;
+}

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -56,3 +56,11 @@ export interface TeamScheduleResponse {
   content: PracticeSchedule[];
   pageInfo: PageInfo;
 }
+
+// 동아리 post 타입
+export interface TeamScheduleFormData {
+  name: string;
+  startDatetime: string;
+  endDatetime: string;
+  noPosition: string | null;
+}


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- Closes #50

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 팀 페이지 UI 작업
- 팀 일정 등록/  삭제/ 조회 API 연결
- 페이지네이션

## **✅ 변경 사항**

### 팀 페이지 UI 작업
- 일정 컴포넌트 디자인 수정
- 일정 등록 모달 추가
  - 마감 시간은 시간만 입력하면 날짜는 시작 날짜 당일로 자동 지정되도록 함
  (이렇게 해야 사용자가 편할것 같다는 생각)
  - 유효성 검사 추가
  - 라디오 버튼 추가 (하나만 고르기)
- 팀 페이지 미디어쿼리 설정
  - 버튼들 이동, 필터링 버튼 이동하여 모바일에서 **시간표 잘보이게** 수정
  - 필터링 버튼 정렬 수정, wrap 추가
- 시간표가 더 잘 보이도록 디자인 조정
- 일정 컴포넌트에 삭제 버튼 추가
- 페이지네이션 추가
- 서버에서 받아온 일정이 없을 경우 일정이 없습니다 추가

### 팀 페이지 API 연결
- 일정 등록 연결
- 일정 등록시 모달 자동 닫힘 + 새로고침
- 일정 삭제
- 일정 삭제시 역시 새로고침 가능

## **📸 스크린샷 (선택)**

https://github.com/user-attachments/assets/36bacf9a-9d7e-4577-a5db-ba26124db62a

<img width="1452" alt="스크린샷 2025-06-07 오전 4 33 54" src="https://github.com/user-attachments/assets/adb103dd-7de5-4478-9983-f271e1ddeb79" />

<img width="1452" alt="스크린샷 2025-06-07 오전 4 34 07" src="https://github.com/user-attachments/assets/40d68042-6b75-4205-9987-2247afed5e34" />

## **💬 코멘트**

- 한게 많네요.. 여기는 진짜 꼼꼼히 해서 손 안봐도 됩니다..
   저는 뻗습니다.. GG
