### PR TITLE
[Feature/message] 카카오톡 공유하기 메세지 연결

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
       type="text/javascript" 
       src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAOMAP_APP_KEY%&libraries=services,clusterer,drawing">
     </script>
+    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,16 @@ import { queryClient } from "./config/queryClient";
 import { routes, publicRoutes } from "@/routes/Routes";
 import PrivateRoute from "@/routes/PrivateRoute";
 
+import { useEffect } from "react";
+
 function App() {
+  // 카카오 메세지 공유를 위한 추가
+  useEffect(() => {
+    if (window.Kakao && !window.Kakao.isInitialized()) {
+      window.Kakao.init(import.meta.env.VITE_KAKAO_JAVASCRIPT_KEY);
+    }
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <GlobalToast />

--- a/src/apis/club.ts
+++ b/src/apis/club.ts
@@ -54,7 +54,7 @@ export const useGetClubMembers = (id: string) => {
 };
 
 export const useInviteClub = (id: string) => {
-  return usePost<void, { link: string }>(
+  return usePost<void, { code: string }>(
     buildPath(ApiEndpotins.CLUB_INVITE, { id })
   );
 };

--- a/src/apis/team.ts
+++ b/src/apis/team.ts
@@ -29,7 +29,7 @@ export const useGetMyTeamList = () => {
 };
 
 export const useInviteTeam = (id: string) => {
-  return usePost<void, { link: string }>(
+  return usePost<void, { code: string }>(
     buildPath(ApiEndpotins.TEAM_INVITE, { id })
   );
 };

--- a/src/components/modal/inviteModal/InviteModal.tsx
+++ b/src/components/modal/inviteModal/InviteModal.tsx
@@ -8,6 +8,22 @@ import Modal from "../Modal";
 import styles from "./InviteModal.module.css";
 import kakao from "@/pages/vote/style/kakao.svg";
 
+declare global {
+  interface Window {
+    // Kakao: any;
+    Kakao: {
+      init: (key: string) => void;
+      isInitialized: () => boolean;
+      Link: {
+        sendCustom: (options: {
+          templateId: number;
+          templateArgs?: Record<string, string>;
+        }) => void;
+      };
+    };
+  }
+}
+
 interface InviteModalProps {
   data: AxiosResponse<ApiResponse<{ code: string }>> | undefined;
   mutate: () => void;
@@ -71,7 +87,25 @@ const InviteModal = ({ data, mutate, type }: InviteModalProps) => {
 
           {/* 카톡 공유 */}
           <div className={styles.btn_container}>
-            <Button className={styles.share_btn} variant="kakao">
+            <Button
+              className={styles.share_btn}
+              variant="kakao"
+              onClick={() => {
+                if (!window.Kakao?.Link || !inviteCode) return;
+
+                const templateId = type === "club" ? 121060 : 121500;
+                const nameKey = type === "club" ? "clubName" : "teamName";
+                const nameValue = type === "club" ? "잔디밴드" : "구준표금잔디"; // 여기 props로 변경 예정
+
+                window.Kakao.Link.sendCustom({
+                  templateId,
+                  templateArgs: {
+                    [nameKey]: nameValue,
+                    inviteCode, // ${inviteCode}
+                  },
+                });
+              }}
+            >
               카카오톡으로 공유
             </Button>
             <Button

--- a/src/components/modal/inviteModal/InviteModal.tsx
+++ b/src/components/modal/inviteModal/InviteModal.tsx
@@ -53,16 +53,11 @@ const InviteModal = ({ data, mutate, type }: InviteModalProps) => {
             <Input
               readOnly
               type="text"
-              // value={data?.data?.data.link}
               value={fullLink}
               className={styles.input}
             />
             <Button
               className={styles.copy_btn}
-              // onClick={() => {
-              //   setCopied(true);
-              //   navigator.clipboard.writeText(data?.data?.data.link);
-              // }}
               onClick={() => {
                 if (fullLink) {
                   setCopied(true);

--- a/src/components/modal/inviteModal/InviteModal.tsx
+++ b/src/components/modal/inviteModal/InviteModal.tsx
@@ -28,9 +28,10 @@ interface InviteModalProps {
   data: AxiosResponse<ApiResponse<{ code: string }>> | undefined;
   mutate: () => void;
   type: "club" | "team";
+  nameValue: string; // props로 이름 변경하기 위해 추가함
 }
 
-const InviteModal = ({ data, mutate, type }: InviteModalProps) => {
+const InviteModal = ({ data, mutate, type, nameValue }: InviteModalProps) => {
   const [copied, setCopied] = useState(false); // 복사 버튼 클릭시 복사됨!
 
   // 모달에 동아리초대,팀초대 표시 위해서
@@ -95,7 +96,7 @@ const InviteModal = ({ data, mutate, type }: InviteModalProps) => {
 
                 const templateId = type === "club" ? 121060 : 121500;
                 const nameKey = type === "club" ? "clubName" : "teamName";
-                const nameValue = type === "club" ? "잔디밴드" : "구준표금잔디"; // 여기 props로 변경 예정
+                // const nameValue = type === "club" ? "잔디밴드" : "구준표금잔디"; // 여기 props로 변경 예정
 
                 window.Kakao.Link.sendCustom({
                   templateId,

--- a/src/components/modal/inviteModal/InviteModal.tsx
+++ b/src/components/modal/inviteModal/InviteModal.tsx
@@ -96,7 +96,6 @@ const InviteModal = ({ data, mutate, type, nameValue }: InviteModalProps) => {
 
                 const templateId = type === "club" ? 121060 : 121500;
                 const nameKey = type === "club" ? "clubName" : "teamName";
-                // const nameValue = type === "club" ? "잔디밴드" : "구준표금잔디"; // 여기 props로 변경 예정
 
                 window.Kakao.Link.sendCustom({
                   templateId,

--- a/src/components/modal/inviteModal/InviteModal.tsx
+++ b/src/components/modal/inviteModal/InviteModal.tsx
@@ -1,5 +1,4 @@
 // 해당 컴포넌트는 동아리 초대 및 팀 초대를 지원하는 모달 컴포넌트 입니다.
-
 import type { ApiResponse } from "@/apis/types";
 import Button from "@/components/button/Button";
 import Input from "@/components/input/Input";
@@ -16,16 +15,19 @@ interface InviteModalProps {
 }
 
 const InviteModal = ({ data, mutate, type }: InviteModalProps) => {
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState(false); // 복사 버튼 클릭시 복사됨!
 
+  // 모달에 동아리초대,팀초대 표시 위해서
   const name = type === "club" ? "동아리" : "팀";
 
+  //  새 링크 생성시마다 복사 상태 초기화
   useEffect(() => {
     if (!data) return;
     setCopied(false);
   }, [data]);
 
   return (
+    // 모달로 유도하는 버튼
     <Modal
       trigger={
         <Button variant="kakao" className={styles.invite_button}>
@@ -35,6 +37,7 @@ const InviteModal = ({ data, mutate, type }: InviteModalProps) => {
       }
       title={`${name} 초대하기`}
     >
+      {/* 조건부 렌더링 */}
       {data ? (
         <div className={styles.container}>
           <h3>초대 링크가 생성되었습니다 !</h3>

--- a/src/components/modal/inviteModal/InviteModal.tsx
+++ b/src/components/modal/inviteModal/InviteModal.tsx
@@ -45,7 +45,8 @@ const InviteModal = ({ data, mutate, type, nameValue }: InviteModalProps) => {
 
   // 초대코드로 링크 조립
   const inviteCode = data?.data?.data.code;
-  const baseUrl = import.meta.env.VITE_FRONT_URL ?? "http://localhost:5173";
+  const baseUrl =
+    import.meta.env.VITE_FRONT_URL ?? "https://rhythmeetdevelop.netlify.app";
   const fullLink = inviteCode
     ? `${baseUrl}/invite/${type}/accept?code=${inviteCode}`
     : "";

--- a/src/components/modal/inviteModal/InviteModal.tsx
+++ b/src/components/modal/inviteModal/InviteModal.tsx
@@ -9,7 +9,7 @@ import styles from "./InviteModal.module.css";
 import kakao from "@/pages/vote/style/kakao.svg";
 
 interface InviteModalProps {
-  data: AxiosResponse<ApiResponse<{ link: string }>> | undefined;
+  data: AxiosResponse<ApiResponse<{ code: string }>> | undefined;
   mutate: () => void;
   type: "club" | "team";
 }
@@ -25,6 +25,13 @@ const InviteModal = ({ data, mutate, type }: InviteModalProps) => {
     if (!data) return;
     setCopied(false);
   }, [data]);
+
+  // 초대코드로 링크 조립
+  const inviteCode = data?.data?.data.code;
+  const baseUrl = import.meta.env.VITE_FRONT_URL ?? "http://localhost:5173";
+  const fullLink = inviteCode
+    ? `${baseUrl}/invite/${type}/accept?code=${inviteCode}`
+    : "";
 
   return (
     // 모달로 유도하는 버튼
@@ -46,14 +53,21 @@ const InviteModal = ({ data, mutate, type }: InviteModalProps) => {
             <Input
               readOnly
               type="text"
-              value={data?.data?.data.link}
+              // value={data?.data?.data.link}
+              value={fullLink}
               className={styles.input}
             />
             <Button
               className={styles.copy_btn}
+              // onClick={() => {
+              //   setCopied(true);
+              //   navigator.clipboard.writeText(data?.data?.data.link);
+              // }}
               onClick={() => {
-                setCopied(true);
-                navigator.clipboard.writeText(data?.data?.data.link);
+                if (fullLink) {
+                  setCopied(true);
+                  navigator.clipboard.writeText(fullLink);
+                }
               }}
             >
               {copied ? "복사됨!" : "복사"}

--- a/src/pages/club/detail/clubInfo/ClubInfo.tsx
+++ b/src/pages/club/detail/clubInfo/ClubInfo.tsx
@@ -73,6 +73,7 @@ const ClubInfo = ({
         </div>
 
         <div className={styles.left_title}>
+          {/* 컴포넌트 아니고, 클럽 Info 내에 있는 모달임. */}
           <InviteModal />
 
           {mine && (

--- a/src/pages/club/detail/clubInfo/ClubInfo.tsx
+++ b/src/pages/club/detail/clubInfo/ClubInfo.tsx
@@ -74,7 +74,7 @@ const ClubInfo = ({
 
         <div className={styles.left_title}>
           {/* 컴포넌트 아니고, 클럽 Info 내에 있는 모달임. */}
-          <InviteModal />
+          <InviteModal nameValue={club.name} />
 
           {mine && (
             <>

--- a/src/pages/club/detail/clubInfo/InviteModal.tsx
+++ b/src/pages/club/detail/clubInfo/InviteModal.tsx
@@ -3,12 +3,19 @@ import { useParams } from "react-router-dom";
 import { useInviteClub } from "@/apis/club"; // 클럽 초대코드 생성
 import InviteModal from "@/components/modal/inviteModal/InviteModal";
 
-const InviteClub = () => {
+const InviteClub = ({ nameValue }: { nameValue: string }) => {
   const { id } = useParams(); // URL에서 id 가져오기
   const { data, mutate } = useInviteClub(id ?? ""); // id가 없으면 빈 문자열
 
   // 여기서 컴포넌트 호출하는듯함.
-  return <InviteModal data={data} mutate={mutate} type="club" />;
+  return (
+    <InviteModal
+      data={data}
+      mutate={mutate}
+      type="club"
+      nameValue={nameValue}
+    />
+  );
 };
 
 export default InviteClub;

--- a/src/pages/club/detail/clubInfo/InviteModal.tsx
+++ b/src/pages/club/detail/clubInfo/InviteModal.tsx
@@ -1,11 +1,13 @@
+// 이건 클럽 내의 invite 모달
 import { useParams } from "react-router-dom";
-import { useInviteClub } from "@/apis/club";
+import { useInviteClub } from "@/apis/club"; // 클럽 초대코드 생성
 import InviteModal from "@/components/modal/inviteModal/InviteModal";
 
 const InviteClub = () => {
   const { id } = useParams(); // URL에서 id 가져오기
   const { data, mutate } = useInviteClub(id ?? ""); // id가 없으면 빈 문자열
 
+  // 여기서 컴포넌트 호출하는듯함.
   return <InviteModal data={data} mutate={mutate} type="club" />;
 };
 

--- a/src/pages/team/detail/TeamDetail.tsx
+++ b/src/pages/team/detail/TeamDetail.tsx
@@ -46,7 +46,7 @@ const TeamDetail = () => {
             >
               내 시간표 입력
             </Button>
-            <InviteTeam />
+            <InviteTeam nameValue={team.name} />
           </div>
         )}
       </header>

--- a/src/pages/team/detail/modals/InviteTeam.tsx
+++ b/src/pages/team/detail/modals/InviteTeam.tsx
@@ -3,11 +3,18 @@ import { useParams } from "react-router-dom";
 import { useInviteTeam } from "@/apis/team";
 import InviteModal from "@/components/modal/inviteModal/InviteModal";
 
-const InviteTeam = () => {
+const InviteTeam = ({ nameValue }: { nameValue: string }) => {
   const { id } = useParams();
   const { data, mutate } = useInviteTeam(id ?? "");
 
-  return <InviteModal data={data} mutate={mutate} type="team" />;
+  return (
+    <InviteModal
+      data={data}
+      mutate={mutate}
+      type="team"
+      nameValue={nameValue}
+    />
+  );
 };
 
 export default InviteTeam;

--- a/src/pages/team/detail/modals/InviteTeam.tsx
+++ b/src/pages/team/detail/modals/InviteTeam.tsx
@@ -1,12 +1,13 @@
-import InviteModal from "@/components/modal/inviteModal/InviteModal";
+// 이건 팀 내의 invite 모달
 import { useParams } from "react-router-dom";
 import { useInviteTeam } from "@/apis/team";
+import InviteModal from "@/components/modal/inviteModal/InviteModal";
 
 const InviteTeam = () => {
   const { id } = useParams();
   const { data, mutate } = useInviteTeam(id ?? "");
 
-  return <InviteModal type="team" data={data} mutate={mutate} />;
+  return <InviteModal data={data} mutate={mutate} type="team" />;
 };
 
 export default InviteTeam;

--- a/src/pages/vote/result/VoteResult.module.css
+++ b/src/pages/vote/result/VoteResult.module.css
@@ -1,8 +1,3 @@
-.vote_result_container {
-  /* margin: 3vh 5vw; */
-  margin-top: 3vh;
-}
-
 /* 투표 제목 및 필터링 */
 .header {
   display: flex;

--- a/src/pages/vote/select/Vote.module.css
+++ b/src/pages/vote/select/Vote.module.css
@@ -1,8 +1,3 @@
-.vote_container {
-  /* margin: 3vh 5vw; */
-  margin-top: 3vh;
-}
-
 /* 투표 제목 및 버튼 */
 .header {
   display: flex;


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- Closes #FRONT_I_094

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 메세지에 들어갈 사진 제작
- 팀 초대, 동아리 초대 카카오톡 API 연결

## **✅ 변경 사항**

- 메세지에 들어갈 사진 제작 (리드미에도 추가하는걸로해요 ㅎㅎ.)
- **초대 코드 수정**
  - 기존에 백엔드에서 전체 url이 넘어오는것을 프론트에서 처리하도록 수정. 백엔드에서는 코드만 넘어옵니다.
- **동아리 이름 / 팀 이름 props로 처리**
  - 카카오톡 메세지 공유시 해당 동아리 이름으로 변경되어 전송
- 투표 결과 페이지 마진 제거
- 현재 초대 코드 링크의 경우는 dev 도메인으로 연결되도록 설정하였습니다.

## **📸 스크린샷 (선택)**
![image](https://github.com/user-attachments/assets/0b26e797-fc23-43ea-97c8-5f9ab48efffd)

![image](https://github.com/user-attachments/assets/213a6398-eb16-4525-9b9e-5989288bd8d4)

![Presentation](https://github.com/user-attachments/assets/ac1a5e51-5cdb-463e-b9a2-e22c526e4d3e)


## **💬 코멘트**

- 다음 PR때 수정해야할 부분
- 이미 가입한 동아리일 경우 무한 로딩창이 뜨고있음. 그 동아리 페이지로 리다이렉트가 안되고있음 (수정예정
- 곡 투표 카카오톡 공유하기 연결 예정
