### PR TITLE
[Fix/refactor] 1차 리팩토링 - 연습 일정, 마이페이지, 그래프, 페이지네이션, 공연 홍보 게시판

### DIFF
--- a/src/apis/mypage.ts
+++ b/src/apis/mypage.ts
@@ -10,12 +10,5 @@ export const useGetInfo = () => {
 
 // 내 정보 수정
 export const usePatchInfo = () => {
-  return usePatch<FormData>(ApiEndpotins.ME, {
-    onSuccess: (response) => {
-      console.log("✅ 서버 응답:", response.data);
-    },
-    onError: (error) => {
-      console.error("❌ 요청 실패:", error);
-    },
-  });
+  return usePatch<FormData>(ApiEndpotins.ME);
 };

--- a/src/components/button/Button.module.css
+++ b/src/components/button/Button.module.css
@@ -53,6 +53,12 @@
   color: var(--color-black);
 }
 
+.btn_textAccent {
+  background-color: transparent;
+  color: var(--color-primary);
+  font-weight: bold;
+}
+
 /* IsClicked styles */
 .btn_transparent_clicked {
   background-color: var(--color-button-secondary-bg);

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -2,7 +2,13 @@ import clsx from "clsx";
 import styles from "./Button.module.css";
 
 type ButtonSize = "sm" | "md" | "lg";
-type ButtonVariant = "primary" | "secondary" | "transparent" | "none" | "kakao";
+type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "transparent"
+  | "none"
+  | "kakao"
+  | "textAccent";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size?: ButtonSize;

--- a/src/components/cards/TeamCard.module.css
+++ b/src/components/cards/TeamCard.module.css
@@ -24,13 +24,6 @@
   }
 }
 
-@media (max-width: 475px) {
-  .card {
-    width: 8rem;
-    height: 8rem;
-  }
-}
-
 .notes {
   display: flex;
   align-items: flex-end;
@@ -45,7 +38,6 @@
   top: 80%;
   left: 50%;
   transform: translate(-50%);
-  font-size: var(--text-lg);
   font-weight: var(--font-weight-semibold);
   color: var(--color-text-main);
   line-height: 1.2;
@@ -54,4 +46,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
   width: 100%;
+}
+
+@media (max-width: 475px) {
+  .card {
+    width: 8rem;
+    height: 8rem;
+  }
 }

--- a/src/components/cards/VoteCard.module.css
+++ b/src/components/cards/VoteCard.module.css
@@ -71,4 +71,5 @@
   color: var(--color-white);
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius-lg);
+  white-space: nowrap;
 }

--- a/src/components/pagination/Pagination.module.css
+++ b/src/components/pagination/Pagination.module.css
@@ -2,4 +2,5 @@
   width: fit-content;
   display: flex;
   gap: 0.5rem;
+  margin-top: 2rem;
 }

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -66,7 +66,7 @@ const Pagination: React.FC<PaginationProps> = ({
       </Button>
       <Button
         size="sm"
-        variant={safetyCurrentPage === 1 ? "secondary" : "none"}
+        variant={safetyCurrentPage === 1 ? "textAccent" : "none"}
         onClick={() => handlePageChange(1)}
         disabled={safetyCurrentPage === 1}
       >
@@ -77,7 +77,7 @@ const Pagination: React.FC<PaginationProps> = ({
         <Button
           size="sm"
           key={page}
-          variant={safetyCurrentPage === page ? "secondary" : "none"}
+          variant={safetyCurrentPage === page ? "textAccent" : "none"}
           onClick={() => handlePageChange(page)}
         >
           {page}
@@ -87,7 +87,7 @@ const Pagination: React.FC<PaginationProps> = ({
       {totalPage > 1 && (
         <Button
           size="sm"
-          variant={safetyCurrentPage === totalPage ? "secondary" : "none"}
+          variant={safetyCurrentPage === totalPage ? "textAccent" : "none"}
           onClick={() => handlePageChange(totalPage)}
           disabled={safetyCurrentPage === totalPage}
         >

--- a/src/pages/club/detail/clubCalendar/calendar/Calendar.module.css
+++ b/src/pages/club/detail/clubCalendar/calendar/Calendar.module.css
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-top: 1rem;
+  /* margin-top: 1rem; */
   margin-bottom: 1rem;
 }
 

--- a/src/pages/club/detail/clubCalendar/calendar/Calendar.module.css
+++ b/src/pages/club/detail/clubCalendar/calendar/Calendar.module.css
@@ -20,3 +20,11 @@
   flex-direction: column;
   margin: 1.5rem 0;
 }
+
+@media (max-width: 475px) {
+  .add_but {
+    font-size: 0.75rem;
+    margin-bottom: 0rem;
+    padding: 0.2rem 0.6rem;
+  }
+}

--- a/src/pages/club/detail/clubCalendar/calendar/Header.module.css
+++ b/src/pages/club/detail/clubCalendar/calendar/Header.module.css
@@ -27,3 +27,16 @@
   cursor: pointer;
   color: var(--color-text-primary);
 }
+
+.date_text {
+  white-space: nowrap;
+}
+
+@media (max-width: 475px) {
+  .header {
+    font-size: medium;
+  }
+  .today_button {
+    font-size: var(--text-sm);
+  }
+}

--- a/src/pages/club/detail/clubInfo/ClubInfo.module.css
+++ b/src/pages/club/detail/clubInfo/ClubInfo.module.css
@@ -85,6 +85,7 @@
   }
   .member_box {
     justify-content: center;
+    gap: 0.5rem;
   }
   .left_title {
     margin-top: 0.5rem;

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -20,7 +20,7 @@ import { buildPath } from "@/utils/buildPath";
 import type { TimeTableResponse } from "@/types/timeTable";
 
 const MyPage = () => {
-  const { data: myInfoResponse } = useGetInfo();
+  const { data: myInfoResponse, refetch } = useGetInfo();
   const { data: myTimeTables, isLoading } = useGetMyTimeTables();
   const { data: myTeamLists, isLoading: MyTeamLoading } = useGetMyTeamList();
   const navigate = useNavigate();
@@ -53,7 +53,13 @@ const MyPage = () => {
               title="마이프로필 수정하기"
               trigger={<button>수정하기</button>}
             >
-              <ProfilEdit myInfo={myInfo} />
+              {(setOpen) => (
+                <ProfilEdit
+                  myInfo={myInfo}
+                  setOpen={setOpen}
+                  refetch={refetch}
+                />
+              )}
             </Modal>
           </header>
           <div className={styles.profile_content}>

--- a/src/pages/mypage/ProfilEdit.tsx
+++ b/src/pages/mypage/ProfilEdit.tsx
@@ -16,6 +16,8 @@ import { usePatchInfo } from "@/apis/mypage";
 const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
 
 interface ProfileEditProps {
+  setOpen: (open: boolean) => void;
+  refetch: () => void;
   myInfo:
     | {
         nickname: string | null;
@@ -25,7 +27,7 @@ interface ProfileEditProps {
     | undefined;
 }
 
-const ProfilEdit = ({ myInfo }: ProfileEditProps) => {
+const ProfilEdit = ({ setOpen, refetch, myInfo }: ProfileEditProps) => {
   const imageInputRef = useRef<HTMLInputElement | null>(null);
   const [imageURL, setimageURL] = useState<string | null>(null);
 
@@ -86,8 +88,6 @@ const ProfilEdit = ({ myInfo }: ProfileEditProps) => {
     const file = imageInputRef.current?.files?.[0];
     const { nickname, position, university } = getValues();
 
-    console.log("선택된 파일:", file);
-
     const formData = new FormData();
     formData.append("nickname", nickname || "null");
     formData.append("position", position || "null");
@@ -97,12 +97,12 @@ const ProfilEdit = ({ myInfo }: ProfileEditProps) => {
       formData.append("profilePhoto", file);
     }
 
-    console.log("===== 전송할 FormData =====");
-    for (const [key, value] of formData.entries()) {
-      console.log(`${key}:`, value);
-    }
-
-    mutate(formData);
+    mutate(formData, {
+      onSuccess: () => {
+        refetch();
+        setOpen(false);
+      },
+    });
   };
 
   return (
@@ -140,7 +140,6 @@ const ProfilEdit = ({ myInfo }: ProfileEditProps) => {
 
         <Field label="포지션" error={errors.position}>
           <PositionSelect
-            // value={formController.watch("position")}
             onValueChange={(position) => {
               formController.setValue("position", position);
             }}

--- a/src/pages/promotions/PromotionMain.module.css
+++ b/src/pages/promotions/PromotionMain.module.css
@@ -102,6 +102,7 @@
   display: flex;
   justify-content: right;
 }
+
 @media (max-width: 450px) {
   .header_nav {
     justify-content: center;
@@ -115,5 +116,12 @@
   .promotion_box {
     padding: 0.2rem;
     margin-bottom: 0.9rem;
+  }
+  .promo_button {
+    top: 0.7rem;
+    left: 0.7rem;
+    padding: 0.3rem 0.7rem;
+    border: 0.5px solid #afafaf;
+    font-size: 0.8rem;
   }
 }

--- a/src/pages/promotions/PromotionMain.module.css
+++ b/src/pages/promotions/PromotionMain.module.css
@@ -1,7 +1,6 @@
 .header_nav {
   display: flex;
   justify-content: space-between;
-  gap: 1rem;
   margin: 1rem 0;
   flex-wrap: wrap;
 }

--- a/src/pages/promotions/PromotionMain.module.css
+++ b/src/pages/promotions/PromotionMain.module.css
@@ -1,3 +1,6 @@
+.container {
+  /* width: 100vw; */
+}
 .header_nav {
   display: flex;
   justify-content: space-between;
@@ -7,7 +10,7 @@
 .header_nav div {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.2rem;
 }
 
 .header_nav_box {
@@ -33,24 +36,12 @@
   font-size: var(--text-2xl);
   font-weight: var(--font-weight-bold);
   color: var(--color-text-sub);
-  margin: 2rem 0;
 }
 
 .promotion_container {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: 1rem;
-}
-
-@media (max-width: 768px) {
-  .header_nav {
-    flex-direction: column;
-    justify-content: center;
-    gap: 1rem;
-  }
-  .promotion_container {
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  }
 }
 
 .promotion_box {
@@ -110,4 +101,19 @@
   width: 100%;
   display: flex;
   justify-content: right;
+}
+@media (max-width: 450px) {
+  .header_nav {
+    justify-content: center;
+    gap: 0.3rem;
+  }
+  .promotion_container {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    /* grid-template-columns: repeat(2, 1fr); */
+    gap: 0rem;
+  }
+  .promotion_box {
+    padding: 0.2rem;
+    margin-bottom: 0.9rem;
+  }
 }

--- a/src/pages/promotions/PromotionMain.tsx
+++ b/src/pages/promotions/PromotionMain.tsx
@@ -52,20 +52,18 @@ const PromotionMain = () => {
   return (
     <DefaultLayout>
       <main className={styles.container}>
+        <header className={styles.page_title}>동아리 공연 홍보 게시판</header>
         <nav className={styles.header_nav}>
-          <div className={styles.header_nav_box}>
-            <Button
-              size="md"
-              variant="transparent"
-              onClick={() => navigate(PageEndpoints.PROMOTION_MAP)}
-            >
-              지도보기
-            </Button>
-          </div>
+          <Button
+            size="md"
+            variant="transparent"
+            onClick={() => navigate(PageEndpoints.PROMOTION_MAP)}
+          >
+            지도보기
+          </Button>
           <div>
             <Input
               inputSize="md"
-              style={{ flex: 1, minWidth: "10rem" }}
               ref={inputRef} // 🔹 ref 할당
               placeholder="제목, 장소로 검색"
             />
@@ -73,10 +71,14 @@ const PromotionMain = () => {
               검색
             </Button>
           </div>
+          <Button
+            variant="primary"
+            size="md"
+            onClick={() => navigate("/promotion/post")}
+          >
+            글 작성
+          </Button>
         </nav>
-
-        <header className={styles.page_title}>동아리 공연 홍보 게시판</header>
-
         <section className={styles.promotion_container}>
           {promoData.data.content.map((item) => {
             const status = getEventStatus(item.eventDatetime);
@@ -122,15 +124,6 @@ const PromotionMain = () => {
             totalPage={totalPage}
             callback={handlePageChange}
           />
-        </section>
-        <section className={styles.post_button_box}>
-          <Button
-            variant="primary"
-            size="lg"
-            onClick={() => navigate("/promotion/post")}
-          >
-            홍보물 등록
-          </Button>
         </section>
       </main>
     </DefaultLayout>

--- a/src/pages/promotions/PromotionMain.tsx
+++ b/src/pages/promotions/PromotionMain.tsx
@@ -55,21 +55,21 @@ const PromotionMain = () => {
         <nav className={styles.header_nav}>
           <div className={styles.header_nav_box}>
             <Button
-              size="lg"
+              size="md"
               variant="transparent"
               onClick={() => navigate(PageEndpoints.PROMOTION_MAP)}
             >
               지도보기
             </Button>
           </div>
-          <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+          <div>
             <Input
-              inputSize="lg"
+              inputSize="md"
               style={{ flex: 1, minWidth: "10rem" }}
               ref={inputRef} // 🔹 ref 할당
               placeholder="제목, 장소로 검색"
             />
-            <Button variant="transparent" size="lg" onClick={handleSearch}>
+            <Button variant="transparent" size="md" onClick={handleSearch}>
               검색
             </Button>
           </div>

--- a/src/pages/promotions/detail/Comment.module.css
+++ b/src/pages/promotions/detail/Comment.module.css
@@ -1,6 +1,6 @@
 .comment_container {
   box-sizing: border-box;
-  padding: 1rem;
+  /* padding: 1rem; */
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -13,7 +13,7 @@
 }
 .comment_input {
   display: flex;
-  padding: 0 1rem;
+  /* padding: 0 1rem; */
 }
 
 .page_navigate_box {

--- a/src/pages/promotions/detail/Comment.tsx
+++ b/src/pages/promotions/detail/Comment.tsx
@@ -72,11 +72,11 @@ const Comment = () => {
       <section className={styles.comment_input}>
         <Input
           inputSize="lg"
-          style={{ flex: "1", marginRight: "1rem" }}
+          style={{ flex: "1", marginRight: "0.3rem" }}
           ref={inputRef}
         />
         <Button size="md" onClick={handleAddComment}>
-          댓글달기
+          작성
         </Button>
       </section>
       <section className={styles.comment_container}>

--- a/src/pages/promotions/detail/DetailContent.module.css
+++ b/src/pages/promotions/detail/DetailContent.module.css
@@ -43,7 +43,7 @@
 }
 .promotion_container {
   box-sizing: border-box;
-  padding: 2rem;
+  padding: 2rem 0;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -51,27 +51,13 @@
 .promotion_info_box {
   display: flex;
 }
+
 .promotion_img {
   width: 25%;
-  min-width: 200px;
+  min-width: 300px;
   aspect-ratio: 376 / 504;
   object-fit: cover;
   border-radius: var(--radius-xl);
-}
-
-@media (max-width: 768px) {
-  .promotion_info_box {
-    flex-direction: column;
-    gap: 1rem;
-  }
-  .promotion_img {
-    margin: 0 auto;
-    min-width: 200px;
-  }
-
-  .promotion_container {
-    padding: 2rem 0;
-  }
 }
 
 .promotion_like_box {
@@ -143,4 +129,24 @@
   margin-top: 1.5rem;
   display: flex;
   flex-direction: column;
+}
+
+@media (max-width: 768px) {
+  .promotion_info_box {
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .info {
+    white-space: nowrap;
+    font-size: smaller;
+  }
+
+  .promotion_img {
+    margin: 0 auto;
+    min-width: 200px;
+  }
+
+  .promotion_info {
+    padding: 0;
+  }
 }

--- a/src/pages/promotions/post/CreatePost.module.css
+++ b/src/pages/promotions/post/CreatePost.module.css
@@ -2,7 +2,7 @@
   margin: 0 auto;
   text-align: center;
   color: #707070;
-  width: 80%;
+  width: 100%;
 }
 
 .post_header {

--- a/src/pages/team/detail/scheduleBoard/AddPractice.tsx
+++ b/src/pages/team/detail/scheduleBoard/AddPractice.tsx
@@ -68,7 +68,18 @@ export default function AddPractice({ setOpen }: Props) {
   } = form;
 
   // 서버로 전송하기 위해 형식 변경 (서버와 일치)
-  const formatToServer = (date: Date) => date.toISOString().slice(0, 19);
+  const formatToServer = (date: Date) => {
+    const pad = (n: number) => n.toString().padStart(2, "0");
+
+    const year = date.getFullYear();
+    const month = pad(date.getMonth() + 1);
+    const day = pad(date.getDate());
+    const hours = pad(date.getHours());
+    const minutes = pad(date.getMinutes());
+    const seconds = pad(date.getSeconds());
+
+    return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+  };
 
   const { mutate: postSchedules } = usePostTeamSchedules(teamId!);
 

--- a/src/pages/vote/graph/BarChart.module.css
+++ b/src/pages/vote/graph/BarChart.module.css
@@ -2,6 +2,7 @@
 .chart_wrapper {
   width: 100%;
   overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .chart_inner {

--- a/src/pages/vote/graph/BarChart.module.css
+++ b/src/pages/vote/graph/BarChart.module.css
@@ -6,7 +6,8 @@
 
 .chart_inner {
   width: 100%;
-  height: 550px;
+  /* height: 550px; */
+  height: 100vh;
 }
 
 @media (max-width: 768px) {

--- a/src/pages/vote/graph/BarChart.tsx
+++ b/src/pages/vote/graph/BarChart.tsx
@@ -49,7 +49,7 @@ const BarChart = ({ data, keys, filter }: BarChartProps) => {
               direction: "row",
               translateY: 55,
               itemsSpacing: 3,
-              itemWidth: 100,
+              itemWidth: 70,
               itemHeight: 20,
               symbolSize: 10,
               itemDirection: "left-to-right",

--- a/src/pages/vote/graph/BarChart.tsx
+++ b/src/pages/vote/graph/BarChart.tsx
@@ -17,6 +17,44 @@ interface BarChartProps {
   filter: string;
 }
 
+interface CustomTickProps {
+  x: number;
+  y: number;
+  value: string;
+  textAnchor: string;
+}
+
+const CustomTick = ({ x, y, value, textAnchor }: CustomTickProps) => {
+  // 화면 너비 체크
+  const width = typeof window !== "undefined" ? window.innerWidth : 1024;
+
+  // 화면 너비 조건별 최대 글자수 설정
+  const maxLength = width <= 400 ? 5 : width <= 768 ? 8 : 20;
+
+  const truncate = (str: string, len: number) =>
+    str.length > len ? str.slice(0, len) + "…" : str;
+
+  const [artist = "", title = ""] = value.split("-");
+
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <text textAnchor={textAnchor}>
+        <title>{value}</title> {/* 전체 텍스트 툴팁 */}
+        <tspan x="0" dy="1rem" style={{ fontSize: 8, fill: "#555" }}>
+          {truncate(artist.trim(), maxLength)}
+        </tspan>
+        <tspan
+          x="0"
+          dy="1.2em"
+          style={{ fontSize: 10, fontWeight: "bold", fill: "#222" }}
+        >
+          {truncate(title.trim(), maxLength)}
+        </tspan>
+      </text>
+    </g>
+  );
+};
+
 const BarChart = ({ data, keys, filter }: BarChartProps) => {
   return (
     // div안에 스타일 지정해놓아야 출력됨.
@@ -25,19 +63,18 @@ const BarChart = ({ data, keys, filter }: BarChartProps) => {
         <ResponsiveBar
           data={data}
           keys={keys}
-          indexBy="song"
+          // indexBy="song"
+          indexBy="id"
           margin={{ top: 50, right: 10, bottom: 50, left: 40 }}
           groupMode="grouped"
           axisBottom={{
-            legendOffset: 32,
+            renderTick: CustomTick,
+            legendOffset: 36,
           }}
           axisLeft={{
             legendOffset: -40,
           }}
           totalsOffset={9}
-          // labelSkipWidth={12}
-          // labelSkipHeight={12}
-          // enableLabel={true}
           labelSkipWidth={0}
           labelSkipHeight={0}
           labelPosition="end"

--- a/src/pages/vote/graph/BarChart.tsx
+++ b/src/pages/vote/graph/BarChart.tsx
@@ -72,6 +72,7 @@ const BarChart = ({ data, keys, filter }: BarChartProps) => {
                 return "#ccc";
             }
           }}
+          motionConfig="stiff"
         />
       </div>
     </section>

--- a/src/pages/vote/result/VoteResult.tsx
+++ b/src/pages/vote/result/VoteResult.tsx
@@ -12,12 +12,15 @@ const VoteResult = () => {
   const navigate = useNavigate();
   const { poll } = usePollStore();
 
+  console.log(poll);
+
   const [filter, setFilter] = useState("기본");
 
   const voteData = useMemo(() => {
     if (!poll?.songs) return [];
 
     const base = poll.songs.map((song) => ({
+      id: `${song.artistName}-${song.songName}`, // 그래프 중복 구분을 위한 아이디 추가
       song: song.songName,
       좋아요: song.likeCount,
       별로예요: song.dislikeCount,
@@ -39,6 +42,7 @@ const VoteResult = () => {
           const 긍정 = item["좋아요"] + item["하않존중"];
           const 부정 = item["별로예요"] + item["실력부족"];
           return {
+            id: item.id,
             song: item.song,
             긍정,
             부정,

--- a/src/pages/vote/select/Recommend.tsx
+++ b/src/pages/vote/select/Recommend.tsx
@@ -28,9 +28,11 @@ export type VoteFormData = z.infer<typeof voteFormSchema>;
 interface RecommendProps {
   setOpen: (open: boolean) => void;
   refetch: () => void;
+  // 중복 방지를 위해 이미 등록된 곡 넘기도록 수정
+  existingSongs: { songName: string; artistName: string }[];
 }
 
-const Recommend = ({ setOpen, refetch }: RecommendProps) => {
+const Recommend = ({ setOpen, refetch, existingSongs }: RecommendProps) => {
   const { id: pollId } = useParams();
   // 스키마랑 연결
   const form = useForm<VoteFormData>({
@@ -45,6 +47,17 @@ const Recommend = ({ setOpen, refetch }: RecommendProps) => {
   const { mutate: postSong } = usePostPoll(pollId!);
 
   const onSubmit = (data: VoteFormData) => {
+    const isDuplicate = existingSongs.some(
+      (song) =>
+        song.songName.trim() === data.songName.trim() &&
+        song.artistName.trim() === data.artistName.trim()
+    );
+
+    if (isDuplicate) {
+      alert("이미 같은 곡과 가수가 등록되어 있어요!");
+      return;
+    }
+
     postSong(data, {
       onSuccess: () => {
         refetch();

--- a/src/pages/vote/select/Vote.tsx
+++ b/src/pages/vote/select/Vote.tsx
@@ -41,7 +41,16 @@ const Vote = () => {
               결과보기
             </Button>
             <Modal title="곡 추천하기" trigger={<Button>곡 추가</Button>}>
-              {(setOpen) => <Recommend setOpen={setOpen} refetch={refetch} />}
+              {(setOpen) => (
+                <Recommend
+                  setOpen={setOpen}
+                  refetch={refetch}
+                  existingSongs={poll.songs.map((s) => ({
+                    songName: s.songName,
+                    artistName: s.artistName,
+                  }))}
+                />
+              )}
             </Modal>
             <Button className={styles.share}>
               <img src={kakao} />

--- a/src/pages/vote/select/VoteSongCard.module.css
+++ b/src/pages/vote/select/VoteSongCard.module.css
@@ -26,7 +26,7 @@ iframe {
 
 @media (max-width: 765px) {
   .song_card {
-    margin: 0 4vw;
+    /* margin: 0 4vw; */
   }
 }
 

--- a/src/utils/dateStatus.ts
+++ b/src/utils/dateStatus.ts
@@ -74,7 +74,7 @@ export const getEventStatus = (eventDatetime: Date | string): EventStatus => {
 
   if (eventDay.getTime() === today.getTime()) {
     return {
-      text: "D-Day",
+      text: "공연중",
       backgroundColor: "var(--color-bg-toast-success)",
       color: "var(--color-button-primary-text)",
     };
@@ -82,7 +82,7 @@ export const getEventStatus = (eventDatetime: Date | string): EventStatus => {
     return {
       text: "공연 예정",
       backgroundColor: "var(--color-white)",
-      color: "var(--color-text-main)",
+      color: "var(--color-label)",
     };
   } else {
     return {

--- a/src/variables.css
+++ b/src/variables.css
@@ -111,6 +111,7 @@
   --radius-button-primary: var(--radius-5xl);
   --color-input: oklch(0.85 0 0);
   --color-error: oklch(0.577 0.245 27.325);
+  --color-label: #777777;
 
   --radius-button-sm: var(--radius-sm);
   --radius-button-md: var(--radius-md);


### PR DESCRIPTION
## **🔗 관련 이슈 번호**

- Closes #이슈번호

## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 연습 일정 오류 해결
- 마이페이지 모달 및 업데이트 개선
- 그래프 중복 오류 해결
- 페이지네이션 UI 개선
- 공연 홍보 게시판 UI 개선

## **✅ 변경 사항**

- **연습 일정**
  - 시간대 서버와 맞지 않는 오류 해결
- **마이페이지 모달 및 업데이트 개선**
  - 수정시 자동 닫힘 + 업데이트
- **그래프 중복 오류 해결**
  - 결과 창에 가수, 곡 제목 보이게 함.
  - 가수와 곡이 완전히 일치할 경우 곡 추가 못하게 막아놓음 
- **캘린더 모바일 친화**
  - 캘린더 미디어 쿼리시 nowrap 및 글자 크기 수정
- **페이지네이션 UI 개선**
  - 페이지네이션 활성화시 배경색 말고 글자색으로 변경함.
  - 마진 top 추가함
- **공연 홍보 게시판 UI 개선**
  - 모바일상에서 잘 안보여서 2개씩 보이도록 수정.
  - 글쓰기 버튼 상단으로 다시 이동.
  - 그 외에 마진이나 배치 등 수정
  - 디테일 페이지 패딩 제거 및 댓글창 변경
  - 모바일 미디어쿼리 추가 (글자 크기 변경 등)

## **📸 스크린샷 (선택)**
<img width="628" alt="스크린샷 2025-06-16 오후 8 16 37" src="https://github.com/user-attachments/assets/42f89c8c-197c-4a4f-ba9d-af02fa7c00cd" />
<img width="628" alt="스크린샷 2025-06-16 오후 8 17 32" src="https://github.com/user-attachments/assets/18e50ad3-b126-41e8-bf5c-a5a33a3ee642" />
<img width="831" alt="스크린샷 2025-06-16 오후 8 18 28" src="https://github.com/user-attachments/assets/415cf826-cb2b-4690-9054-7162bd40200f" />

## **💬 코멘트**

- 다른부분 수정은 제가 할 테니 지도 부분만 수정해주시면 감사하겠습니다 🥹